### PR TITLE
chore(release): harden pipeline (PAT checkout, tag push, Docker concurrency, changelog notes)

### DIFF
--- a/.changeset/release-pipeline-hardening.md
+++ b/.changeset/release-pipeline-hardening.md
@@ -1,0 +1,5 @@
+---
+"octafuse": patch
+---
+
+release pipeline: inject PAT into checkout/git push for tags, add Docker workflow concurrency, embed CHANGELOG section in GitHub Release notes

--- a/.github/workflows/octafuse-docker-images.yml
+++ b/.github/workflows/octafuse-docker-images.yml
@@ -1,7 +1,7 @@
 # 构建并推送 Octafuse 镜像到 GHCR（可选阿里云 ACR 双推）。
 #
 # 正式发布：推送语义化 Git 标签 vX.Y.Z（由 Release workflow 的 `changeset tag` 产生）触发本 workflow，
-# 默认构建 proxy + admin + migrate，linux/amd64 与 linux/arm64；推送后创建/更新 GitHub Release（正文含各镜像 digest）。
+# 默认构建 proxy + admin + migrate，linux/amd64 与 linux/arm64；推送后创建/更新 GitHub Release（正文含 CHANGELOG 对应版本段与各镜像 digest）。
 #
 # 应急：仍可使用 workflow_dispatch 手动构建（不创建 GitHub Release）。
 #
@@ -38,6 +38,10 @@ on:
         description: 构建 linux/arm64（Apple Silicon / ARM 云主机）
         type: boolean
         default: true
+
+concurrency:
+  group: octafuse-docker-images-${{ github.ref }}
+  cancel-in-progress: false
 
 permissions:
   contents: read
@@ -233,6 +237,14 @@ jobs:
     permissions:
       contents: write
     steps:
+      - name: Checkout (CHANGELOG only)
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.ref }}
+          sparse-checkout: |
+            CHANGELOG.md
+          sparse-checkout-cone-mode: false
+
       - name: Download digest artifacts
         uses: actions/download-artifact@v4
         with:
@@ -245,11 +257,26 @@ jobs:
           set -euo pipefail
           OWNER_REPO_LC=$(echo '${{ github.repository }}' | tr '[:upper:]' '[:lower:]')
           TAG="${{ github.ref_name }}"
+          VERSION="${TAG#v}"
+          awk -v ver="$VERSION" '
+            $0 ~ "^## " ver "$" {flag=1; next}
+            flag && /^## / {exit}
+            flag {print}
+          ' CHANGELOG.md > changelog-section.md || true
+          if [ ! -s changelog-section.md ]; then
+            echo "_(CHANGELOG 中未找到 \`## ${VERSION}\` 段落；请核对 Version PR 是否更新了 CHANGELOG。)_" > changelog-section.md
+          fi
           resolve_digest_file() {
             local s="$1"
             find digest-artifacts -name "${s}.digest" -type f 2>/dev/null | head -1
           }
           {
+            echo "## What's changed"
+            echo ""
+            cat changelog-section.md
+            echo ""
+            echo "---"
+            echo ""
             echo "## Container images (GHCR)"
             echo ""
             echo "Tag **${TAG}** — multi-arch manifest digests (proxy / admin / migrate):"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,9 @@
 # 因此当未配置 CHANGESETS_GITHUB_TOKEN 时，本 workflow 在检测到 HEAD 有 v* tag 后会 `gh workflow run` 主动触发 Docker；
 # 若已配置 PAT，则由 tag 的 push 正常触发 Docker，本步骤会跳过以免重复构建。
 #
+# **必读**：`CHANGESETS_GITHUB_TOKEN` 必须同时被下方 `actions/checkout` 的 `token` 引用；否则 `git push` tag
+# 仍走默认 GITHUB_TOKEN，下游 **Octafuse Docker Images** 不会被触发（dispatch 步骤会因「已配 PAT」而跳过）。
+#
 # 若出现「GitHub Actions is not permitted to create or approve pull requests」：
 # 1) 仓库 Settings → Actions → General → Workflow permissions：勾选「Allow GitHub Actions to create and approve pull requests」；
 #    或 2) 在 Repo secrets 配置 CHANGESETS_GITHUB_TOKEN（PAT：contents + pull-requests），见 docs/ops/release-versioning.md。
@@ -33,6 +36,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          token: ${{ secrets.CHANGESETS_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -43,15 +47,19 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      # 与 verify-package-versions.yml 重叠；在此再跑一次便于 Release 流水线内早失败。
       - name: Verify package versions (no drift)
         run: npm run verify:package-versions
 
+      # publish 必须用「单条 npm script」：action 把 publish 拆成 argv，不能写 `changeset tag && ...`。
+      # createGithubReleases: false 时 changesets/action 不会 push tag（其 pushTag 与创建 GH Release 绑定），
+      # 故由 ci:changeset-tag-push 在 changeset tag 后显式 git push origin vX.Y.Z。
       - name: Create Version PR or push tags
         uses: changesets/action@v1
         with:
           title: "chore: version packages"
           commit: "chore: version packages"
-          publish: npx changeset tag
+          publish: npm run ci:changeset-tag-push
           createGithubReleases: false
         env:
           # 未配置 CHANGESETS_GITHUB_TOKEN 时回退默认 GITHUB_TOKEN（需仓库允许 Actions 开 PR）
@@ -66,14 +74,24 @@ jobs:
         run: |
           set -euo pipefail
           if [ -n "${CHANGESETS_PAT}" ]; then
-            echo "CHANGESETS_GITHUB_TOKEN is set; tag push should have triggered Docker — skip dispatch."
+            echo "PAT mode detected; expecting tag push to chain-trigger Docker — skip dispatch."
             exit 0
           fi
+          PKG_VERSION="$(node -p "JSON.parse(require('fs').readFileSync('package.json','utf8')).version")"
+          EXPECTED_TAG="v${PKG_VERSION}"
+          echo "Root package.json version: ${PKG_VERSION} (expected release tag: ${EXPECTED_TAG})"
+          echo "GITHUB_SHA: ${GITHUB_SHA}"
           git fetch origin --tags
+          # 防御性切回 GITHUB_SHA（changesets/action 通常不改本地 HEAD，但保险）。
           git checkout "${GITHUB_SHA}"
           TAG=$(git describe --tags --exact-match HEAD 2>/dev/null || true)
           if [ -z "${TAG}" ]; then
-            echo "No semver tag on ${GITHUB_SHA} (likely only opened Version PR) — nothing to dispatch."
+            if git ls-remote --tags origin -l "${EXPECTED_TAG}" | grep -q .; then
+              echo "::notice::No tag on HEAD, but origin already has ${EXPECTED_TAG}. \`changeset tag\` skips when the tag exists remotely (even on another commit) — **优先**用新 changeset bump 版本再走 Version PR；**勿**轻易删除远端公共 tag；确需修复远端 tag 后再重跑 Release。"
+            else
+              echo "::notice::No exact tag on ${GITHUB_SHA}. Often: changesets/action only opened a Version PR (unreleased .changeset/*.md still on main), or \`changeset tag\` did not push."
+            fi
+            echo "Nothing to dispatch."
             exit 0
           fi
           case "${TAG}" in

--- a/docs/ops/release-versioning.md
+++ b/docs/ops/release-versioning.md
@@ -39,6 +39,8 @@ flowchart LR
   DOCKER --> REL
 ```
 
+**并发**：`octafuse-docker-images.yml` 已配置 `concurrency`（`group: octafuse-docker-images-${{ github.ref }}`，`cancel-in-progress: false`）。同一 ref（如同一 `v*` tag）的重复触发会**串行**执行，避免并行推送互相覆盖 digest。
+
 1. **`.github/workflows/release.yml`**（`push` → `main`）  
    - 若有未消费的 `.changeset/*.md`：打开 **「chore: version packages」** PR（更新版本、`CHANGELOG.md`）。  
    - 若无待处理 changeset 且版本已更新：执行 **`npx changeset tag`**，推送 **`vX.Y.Z`** Git 标签。  
@@ -47,7 +49,7 @@ flowchart LR
 
 2. **`.github/workflows/octafuse-docker-images.yml`**（**`push` → `tags/v*`**，或由 Release **dispatch**；或 **`workflow_dispatch`**）  
    - 构建并推送 **GHCR**（及可选 **ACR**）三镜像。  
-   - 在 **tag 发版**路径下创建/更新 **GitHub Release**，正文中写入各镜像 **digest**。
+   - 在 **tag 发版**路径下创建/更新 **GitHub Release**：正文含 **`CHANGELOG.md` 中对应 `## X.Y.Z` 段落**（What's changed）与各镜像 **digest**。
 
 3. **`.github/workflows/verify-package-versions.yml`**  
    - PR / `main` / `v*` 标签上校验：根与 workspace **`version` 一致**；在 **tag** 上校验 **`v` + version** 与标签名一致。
@@ -84,11 +86,18 @@ flowchart LR
    - **Classic**：勾选 **`repo`**（或至少 **Contents**、**Pull requests**）。  
    - **Fine-grained**：该仓库 **Contents: Read and write**、**Pull requests: Read and write**、**Metadata: Read**。  
 2. 在仓库 **Settings** → **Secrets and variables** → **Actions** 中新增 secret：**`CHANGESETS_GITHUB_TOKEN`**，值为上述 PAT。  
-3. **`.github/workflows/release.yml`** 已配置：`GITHUB_TOKEN` 优先使用 **`secrets.CHANGESETS_GITHUB_TOKEN`**，未设置时回退 **`secrets.GITHUB_TOKEN`**。
+3. **`.github/workflows/release.yml`** 已配置：`GITHUB_TOKEN` 优先使用 **`secrets.CHANGESETS_GITHUB_TOKEN`**，未设置时回退 **`secrets.GITHUB_TOKEN`**。  
+4. **必读**：`changesets/action` 与 **`scripts/ci/push-root-release-tag.mjs`** 里的 `git push` 依赖 **`actions/checkout@v4` 的 `token`**。本仓已设为 `token: ${{ secrets.CHANGESETS_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}`。若只把 PAT 写在 `env.GITHUB_TOKEN` 而 **checkout 仍用默认凭据**，`git push` tag 仍会走默认 **`GITHUB_TOKEN`**，**不会**链式触发 **Octafuse Docker Images**（dispatch 步骤还会因「已配 PAT」而跳过），表现为 **PAT 已配但 Docker 不跑**。
 
 ### 本次失败后的补救
 
 若日志里已成功 **`git push origin HEAD:changeset-release/main`**，但 **创建 PR 失败**：到 GitHub 上打开分支 **`changeset-release/main`**，**手动发起 PR 合并到 `main`** 即可；合并后下一轮 Release 会尝试 **`changeset tag`**（若已无待处理 changeset）。
+
+### Tag 未上 GitHub / Release 成功但无 `v*` 且无 Docker
+
+1. **`changesets/action` + `createGithubReleases: false`**：上游实现里 **`git.pushTag` 与创建 GitHub Release 绑在一起**；为 false 时即使用 `changeset tag` 打出了**本地** tag，也不会替你 `git push`。本仓库用 **`npm run ci:changeset-tag-push`**（`changeset tag` + `scripts/ci/push-root-release-tag.mjs`）在 CI 里显式推送 **`vX.Y.Z`**。  
+2. **日志已跑 `changeset tag` 但后续仍报 HEAD 无 semver tag**：多为 **远端已有同名 `vX.Y.Z`**，`changeset tag` 会整段跳过（不写本地 tag）——需 **bump 新版本**（新 changeset + 再走 Version PR）或 **谨慎**处理远端错误 tag 后再跑一次 Release。  
+3. **PAT 已配但 Docker 仍未跑**：核对 **`release.yml`** 中 **`actions/checkout`** 是否传入 **`token: ${{ secrets.CHANGESETS_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}`**（见上文「做法 B」第 4 条）。
 
 ## 维护者日常操作
 
@@ -108,7 +117,7 @@ npx changeset
 
 ### 3. 打标签与镜像
 
-合并 Version PR 再次触发 **Release** → **`changeset tag`** 推送 **`vX.Y.Z`** → **Docker**（见上文「Docker 触发」：PAT 走 tag 事件；仅 `GITHUB_TOKEN` 时由 Release **dispatch**）→ **GitHub Release** 就绪。
+合并 Version PR 再次触发 **Release** → **`npm run ci:changeset-tag-push`**（`changeset tag` + 推送 **`vX.Y.Z`**）→ **Docker**（见上文「Docker 触发」：PAT 走 tag 事件；仅 `GITHUB_TOKEN` 时由 Release **dispatch**）→ **GitHub Release** 就绪（正文含 **`CHANGELOG.md` 对应版本段** + 镜像 **digest**）。
 
 ### 4. 热修（patch）
 

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
 	"scripts": {
 		"postinstall": "patch-package",
 		"verify:package-versions": "node scripts/ci/verify-package-versions.mjs",
+		"ci:changeset-tag-push": "changeset tag && node scripts/ci/push-root-release-tag.mjs",
 		"dev:proxy": "npm run dev -w @octafuse/proxy",
 		"dev:proxy:node": "dotenv -c -- npm run dev:node -w @octafuse/proxy",
 		"dev:admin": "npm run preview -w @octafuse/admin",

--- a/scripts/ci/push-root-release-tag.mjs
+++ b/scripts/ci/push-root-release-tag.mjs
@@ -1,0 +1,40 @@
+#!/usr/bin/env node
+/**
+ * After `changeset tag`, push the root semver tag (vX.Y.Z) to origin.
+ *
+ * changesets/action only calls git.pushTag() when createGithubReleases is true;
+ * we keep createGithubReleases false (Docker workflow owns GitHub Release), so we push here.
+ *
+ * If `changeset tag` skipped (e.g. tag already exists on origin), there is no local tag — exit 0.
+ */
+import { execSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const root = join(__dirname, "../..");
+const pkg = JSON.parse(readFileSync(join(root, "package.json"), "utf8"));
+const tag = `v${pkg.version}`;
+
+function localTagPointsToCommit() {
+	try {
+		execSync(`git rev-parse -q --verify "refs/tags/${tag}^{commit}"`, {
+			cwd: root,
+			stdio: "pipe",
+		});
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+if (!localTagPointsToCommit()) {
+	console.log(
+		`No local tag ${tag} after "changeset tag". Usually: origin already has this tag (same version on a different commit), or versions were not bumped.`,
+	);
+	process.exit(0);
+}
+
+console.log(`Pushing release tag ${tag} to origin...`);
+execSync(`git push origin "${tag}"`, { cwd: root, stdio: "inherit" });


### PR DESCRIPTION
## Summary
- `release.yml`: `actions/checkout` uses `CHANGESETS_GITHUB_TOKEN || GITHUB_TOKEN` so `git push` tags chain-trigger Docker when PAT is set; restore `publish: npm run ci:changeset-tag-push`; dispatch step keeps GITHUB_TOKEN-only fallback.
- `package.json` + `scripts/ci/push-root-release-tag.mjs`: explicit push of `vX.Y.Z` after `changeset tag` (main had regressed to `npx changeset tag` only).
- `octafuse-docker-images.yml`: `concurrency` per ref; GitHub Release notes include CHANGELOG section + digests.
- `docs/ops/release-versioning.md`: PAT+checkout, troubleshooting, concurrency.

## After merge
1. Wait for **Release** → **Version Packages** PR (bump includes this patch changeset; **main is already 0.2.0** → expect **0.2.1**).
2. Merge Version PR → tag **v0.2.1** → Docker + GitHub Release.

If **v0.2.0** images were never built (broken publish step), you may instead cherry-pick only workflow fixes onto the tag line you need; this PR follows Changesets to **0.2.1**.

Made with [Cursor](https://cursor.com)