### PR TITLE
fix(release): ensure vX.Y.Z tag for private workspace

### DIFF
--- a/.changeset/v-tag-private-workspace.md
+++ b/.changeset/v-tag-private-workspace.md
@@ -1,0 +1,5 @@
+---
+"octafuse": patch
+---
+
+always create and push root **vX.Y.Z** after `changeset tag` (private workspace default skips `v*` tags)

--- a/docs/ops/release-versioning.md
+++ b/docs/ops/release-versioning.md
@@ -96,6 +96,7 @@ flowchart LR
 ### Tag 未上 GitHub / Release 成功但无 `v*` 且无 Docker
 
 1. **`changesets/action` + `createGithubReleases: false`**：上游实现里 **`git.pushTag` 与创建 GitHub Release 绑在一起**；为 false 时即使用 `changeset tag` 打出了**本地** tag，也不会替你 `git push`。本仓库用 **`npm run ci:changeset-tag-push`**（`changeset tag` + `scripts/ci/push-root-release-tag.mjs`）在 CI 里显式推送 **`vX.Y.Z`**。  
+   - 补充：默认 **`privatePackages.tag` 为 `false`** 时，`changeset tag` **可能不会**生成 **`v*`**（仅 private workspace 时常见）。`push-root-release-tag.mjs` 会在缺少 **`vX.Y.Z`** 时于当前 **HEAD**（或已存在的 `octafuse@X.Y.Z` 等标签指向的提交）**补打** **`vX.Y.Z`** 再推送。若希望 Changesets 自行生成 `name@version` 类标签，可在 **`.changeset/config.json`** 设置 `"privatePackages": { "tag": true }`（可选）。  
 2. **日志已跑 `changeset tag` 但后续仍报 HEAD 无 semver tag**：多为 **远端已有同名 `vX.Y.Z`**，`changeset tag` 会整段跳过（不写本地 tag）——需 **bump 新版本**（新 changeset + 再走 Version PR）或 **谨慎**处理远端错误 tag 后再跑一次 Release。  
 3. **PAT 已配但 Docker 仍未跑**：核对 **`release.yml`** 中 **`actions/checkout`** 是否传入 **`token: ${{ secrets.CHANGESETS_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}`**（见上文「做法 B」第 4 条）。
 

--- a/scripts/ci/push-root-release-tag.mjs
+++ b/scripts/ci/push-root-release-tag.mjs
@@ -1,13 +1,14 @@
 #!/usr/bin/env node
 /**
- * After `changeset tag`, push the root semver tag (vX.Y.Z) to origin.
+ * After `changeset tag`, ensure the root semver tag **vX.Y.Z** exists on origin.
  *
- * changesets/action only calls git.pushTag() when createGithubReleases is true;
- * we keep createGithubReleases false (Docker workflow owns GitHub Release), so we push here.
- *
- * If `changeset tag` skipped (e.g. tag already exists on origin), there is no local tag — exit 0.
+ * - `changesets/action` does not push tags when `createGithubReleases` is false.
+ * - `changeset tag` with default config **does not** create `v*` tags for **private**
+ *   workspace packages (`privatePackages.tag` defaults to false); it may create
+ *   nothing or only `name@version` tags. This script always creates/pushes **vX.Y.Z**
+ *   aligned with root `package.json` `version`.
  */
-import { execSync } from "node:child_process";
+import { execFileSync, execSync } from "node:child_process";
 import { readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -15,26 +16,51 @@ import { fileURLToPath } from "node:url";
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const root = join(__dirname, "../..");
 const pkg = JSON.parse(readFileSync(join(root, "package.json"), "utf8"));
-const tag = `v${pkg.version}`;
+const version = pkg.version;
+const vTag = `v${version}`;
 
-function localTagPointsToCommit() {
+function runCapture(cmd, args) {
+	return execFileSync(cmd, args, { cwd: root, encoding: "utf8" }).trim();
+}
+
+function refExists(ref) {
 	try {
-		execSync(`git rev-parse -q --verify "refs/tags/${tag}^{commit}"`, {
-			cwd: root,
-			stdio: "pipe",
-		});
+		runCapture("git", ["rev-parse", "-q", "--verify", `${ref}^{commit}`]);
 		return true;
 	} catch {
 		return false;
 	}
 }
 
-if (!localTagPointsToCommit()) {
-	console.log(
-		`No local tag ${tag} after "changeset tag". Usually: origin already has this tag (same version on a different commit), or versions were not bumped.`,
+if (!refExists(`refs/tags/${vTag}`)) {
+	const candidates = [
+		`octafuse@${version}`,
+		`@octafuse/core@${version}`,
+		`@octafuse/proxy@${version}`,
+		`@octafuse/admin@${version}`,
+	];
+	let commit = "";
+	for (const c of candidates) {
+		if (refExists(`refs/tags/${c}`)) {
+			commit = runCapture("git", ["rev-parse", `${c}^{commit}`]);
+			console.log(`Creating ${vTag} at ${commit} (from tag ${c})`);
+			break;
+		}
+	}
+	if (!commit) {
+		commit = runCapture("git", ["rev-parse", "HEAD"]);
+		console.log(
+			`Creating ${vTag} at HEAD ${commit} (no per-package tag from changeset; typical for private workspaces)`,
+		);
+	}
+	execFileSync(
+		"git",
+		["tag", "-a", vTag, "-m", `release ${version}`, commit],
+		{ cwd: root, stdio: "inherit" },
 	);
-	process.exit(0);
+} else {
+	console.log(`Local tag ${vTag} already exists.`);
 }
 
-console.log(`Pushing release tag ${tag} to origin...`);
-execSync(`git push origin "${tag}"`, { cwd: root, stdio: "inherit" });
+console.log(`Pushing release tag ${vTag} to origin...`);
+execSync(`git push origin "${vTag}"`, { cwd: root, stdio: "inherit" });


### PR DESCRIPTION
## Problem
`changeset tag` defaults `privatePackages.tag` to **false**, so **no `v*` tag** was created on Version PR merge — Docker never ran for **v0.2.1**.

## Fix
`scripts/ci/push-root-release-tag.mjs` now creates an annotated **`vX.Y.Z`** at **HEAD** (or at the commit of an existing `octafuse@X.Y.Z` / `@octafuse/*@X.Y.Z` tag if present), then `git push origin vX.Y.Z`.

Docs updated with optional `privatePackages.tag` note.

Made with [Cursor](https://cursor.com)