### PR TITLE
chore: add changeset for 1.10.2

### DIFF
--- a/.changeset/fix-admin-cookie-secure.md
+++ b/.changeset/fix-admin-cookie-secure.md
@@ -1,0 +1,6 @@
+---
+"octafuse": patch
+"@octafuse/admin": patch
+---
+
+Fix Admin console login being kicked out immediately on plain HTTP (e.g. Docker quickstart): make `admin_session` `Secure` opt-in via `ADMIN_COOKIE_SECURE` instead of always-on ([#36](https://github.com/OctaFuse/octafuse-gateway/issues/36)).


### PR DESCRIPTION
## Summary
- Add patch changeset for Admin session cookie fix already on `main` (`Fixes #36`)
- Bump intended release to **1.10.2** via Changesets Version Packages flow

## Test plan
- [ ] Merge this PR → Release workflow opens **chore: version packages**
- [ ] Merge Version Packages PR → `v1.10.2` tag + Docker images + GitHub Release


Made with [Cursor](https://cursor.com)