### PR TITLE
fix(admin): Docker arm64 SWC musl binding for 2.0.1

### DIFF
--- a/.changeset/admin-docker-swc-musl.md
+++ b/.changeset/admin-docker-swc-musl.md
@@ -1,0 +1,5 @@
+---
+"@octafuse/admin": patch
+---
+
+Fix Admin Docker multi-arch build on `linux/arm64` (Alpine musl): explicitly install `@swc/core-linux-*-musl` after `npm ci --ignore-scripts`, so `next-intl` can load native SWC when evaluating `next.config` under buildx/QEMU.

--- a/Dockerfile.admin
+++ b/Dockerfile.admin
@@ -26,6 +26,20 @@ RUN --mount=type=cache,target=/root/.npm \
 # 树内可能有多份 esbuild（如 @octafuse/core 与 @opennextjs/aws 嵌套版本）；勿用 `npm rebuild esbuild`（会对多版本做错误校验）。
 RUN find node_modules -path '*/esbuild/install.js' -exec node {} \;
 
+# next-intl → @swc/core：加载 next.config 时需要当前平台的 musl 原生绑定。
+# buildx QEMU 交叉构建 linux/arm64 时，npm optionalDependencies 有时会漏装
+# `@swc/core-linux-arm64-musl`，表现为 Failed to load native binding。
+RUN set -eux; \
+	arch="$(uname -m)"; \
+	case "$arch" in \
+		aarch64|arm64) swc_arch=arm64 ;; \
+		x86_64|amd64) swc_arch=x64 ;; \
+		*) echo "unsupported arch: $arch" >&2; exit 1 ;; \
+	esac; \
+	swc_ver="$(node -p "require('./node_modules/@swc/core/package.json').version")"; \
+	npm install --no-save --ignore-scripts "@swc/core-linux-${swc_arch}-musl@${swc_ver}"; \
+	node -e "require('@swc/core')"
+
 COPY packages/core ./packages/core
 COPY packages/admin ./packages/admin
 


### PR DESCRIPTION
## Summary
- `v2.0.0` Docker release failed on **admin** `linux/arm64`: `next-intl` → `@swc/core` could not load `@swc/core-linux-arm64-musl` under buildx/QEMU after `npm ci --ignore-scripts`.
- Explicitly install the Alpine musl SWC binding for the build arch and verify `require('@swc/core')` before `next build`.
- Adds patch changeset → **2.0.1** (do not rewrite `v2.0.0`; proxy/migrate already published under that tag; admin + GitHub Release never completed).

## Test plan
- [ ] Merge → Version Packages PR bumps to 2.0.1
- [ ] Merge Version PR → `v2.0.1` tag
- [ ] Octafuse Docker Images green for proxy/admin/migrate
- [ ] GitHub Release `v2.0.1` has digests


Made with [Cursor](https://cursor.com)