### PR TITLE
chore(release): collapse 2.0.1 into 2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,15 +1,6 @@
 # Changelog
 
-## 2.0.1
-
-### Patch Changes
-
-- [#76](https://github.com/OctaFuse/octafuse-gateway/pull/76) [`6019524`](https://github.com/OctaFuse/octafuse-gateway/commit/601952484c9ca01a5f21d1e4e5e5c79d5e441d8a) Thanks [@dyc87112](https://github.com/dyc87112)! - Fix Admin Docker multi-arch build on `linux/arm64` (Alpine musl): explicitly install `@swc/core-linux-*-musl` after `npm ci --ignore-scripts`, so `next-intl` can load native SWC when evaluating `next.config` under buildx/QEMU.
-
-  Note: `v2.0.0` tagged the 2.0 major line, but its Admin image build failed on arm64 and no GitHub Release was published. Prefer **`v2.0.1`** for a complete proxy/admin/migrate image set. Breaking changes remain those documented under **2.0.0**.
-
 ## 2.0.0
-
 
 ### Major Changes
 
@@ -28,6 +19,8 @@
 ### Patch Changes
 
 - [#74](https://github.com/OctaFuse/octafuse-gateway/pull/74) [`58e6383`](https://github.com/OctaFuse/octafuse-gateway/commit/58e6383c7439fcc72ed5539af299c6c701121f36) Thanks [@dyc87112](https://github.com/dyc87112)! - Improve Images `/v1/images/edits` client-error diagnostics: reject non-`multipart/form-data` Content-Type with an explicit message (instead of a misleading `Missing model`), and log structured `[Gateway Images] request rejected` fields (`contentType`, `bodyKeys`, `hasModel`, …) for all Images 4xx early exits. Proxy also logs truncated JSON bodies for Gateway-generated 4xx responses.
+
+- [#76](https://github.com/OctaFuse/octafuse-gateway/pull/76) [`6019524`](https://github.com/OctaFuse/octafuse-gateway/commit/601952484c9ca01a5f21d1e4e5e5c79d5e441d8a) Thanks [@dyc87112](https://github.com/dyc87112)! - Fix Admin Docker multi-arch build on `linux/arm64` (Alpine musl): explicitly install `@swc/core-linux-*-musl` after `npm ci --ignore-scripts`, so `next-intl` can load native SWC when evaluating `next.config` under buildx/QEMU.
 
 ## 1.11.0
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "octafuse",
-	"version": "2.0.1",
+	"version": "2.0.0",
 	"private": true,
 	"repository": {
 		"type": "git",

--- a/packages/admin/CHANGELOG.md
+++ b/packages/admin/CHANGELOG.md
@@ -1,14 +1,5 @@
 # @octafuse/admin
 
-## 2.0.1
-
-### Patch Changes
-
-- [#76](https://github.com/OctaFuse/octafuse-gateway/pull/76) [`6019524`](https://github.com/OctaFuse/octafuse-gateway/commit/601952484c9ca01a5f21d1e4e5e5c79d5e441d8a) Thanks [@dyc87112](https://github.com/dyc87112)! - Fix Admin Docker multi-arch build on `linux/arm64` (Alpine musl): explicitly install `@swc/core-linux-*-musl` after `npm ci --ignore-scripts`, so `next-intl` can load native SWC when evaluating `next.config` under buildx/QEMU.
-
-- Updated dependencies []:
-  - @octafuse/core@2.0.1
-
 ## 2.0.0
 
 ### Major Changes
@@ -26,6 +17,8 @@
   上线前请用 `scripts/db/export-provider-api-keys.mjs` 导出密钥，再应用迁移 `0015_single_provider_key.sql`。详见 `docs/operators/migrations/single-provider-key-cutover.md`。
 
 ### Patch Changes
+
+- [#76](https://github.com/OctaFuse/octafuse-gateway/pull/76) [`6019524`](https://github.com/OctaFuse/octafuse-gateway/commit/601952484c9ca01a5f21d1e4e5e5c79d5e441d8a) Thanks [@dyc87112](https://github.com/dyc87112)! - Fix Admin Docker multi-arch build on `linux/arm64` (Alpine musl): explicitly install `@swc/core-linux-*-musl` after `npm ci --ignore-scripts`, so `next-intl` can load native SWC when evaluating `next.config` under buildx/QEMU.
 
 - Updated dependencies [[`c8b4372`](https://github.com/OctaFuse/octafuse-gateway/commit/c8b4372217383d550cf47874e3c1416de8b54b6f)]:
   - @octafuse/core@2.0.0

--- a/packages/admin/package.json
+++ b/packages/admin/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@octafuse/admin",
-	"version": "2.0.1",
+	"version": "2.0.0",
 	"private": true,
 	"scripts": {
 		"dev": "next dev",

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,7 +1,5 @@
 # @octafuse/core
 
-## 2.0.1
-
 ## 2.0.0
 
 ### Major Changes

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@octafuse/core",
-	"version": "2.0.1",
+	"version": "2.0.0",
 	"private": true,
 	"type": "module",
 	"bin": {

--- a/packages/proxy/CHANGELOG.md
+++ b/packages/proxy/CHANGELOG.md
@@ -1,12 +1,5 @@
 # @octafuse/proxy
 
-## 2.0.1
-
-### Patch Changes
-
-- Updated dependencies []:
-  - @octafuse/core@2.0.1
-
 ## 2.0.0
 
 ### Major Changes

--- a/packages/proxy/package.json
+++ b/packages/proxy/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@octafuse/proxy",
-	"version": "2.0.1",
+	"version": "2.0.0",
 	"private": true,
 	"type": "module",
 	"scripts": {


### PR DESCRIPTION
## Summary
- Fold the Admin Docker arm64/SWC fix (formerly 2.0.1) into **2.0.0** changelog and set package versions back to **2.0.0**.
- Follow-up ops (after merge): delete GitHub Release/`v2.0.1` tag, move `v2.0.0` to this commit, rebuild GHCR images + GitHub Release for `v2.0.0`.

## Test plan
- [ ] Versions verify CI green
- [ ] After merge: only `v2.0.0` remains as the 2.0 line release


Made with [Cursor](https://cursor.com)