### PR TITLE
fix(admin): make dev:admin work on a clean checkout

### DIFF
--- a/packages/admin/next.config.mjs
+++ b/packages/admin/next.config.mjs
@@ -22,6 +22,10 @@ const nextConfig = {
 	outputFileTracingRoot: workspaceRoot,
 	turbopack: {
 		root: workspaceRoot,
+		resolveAlias: {
+			// Turbopack alias 从 Admin 目录解析；使用相对路径避免绝对路径被误判为 server-relative import。
+			'@octafuse/core': '../core/src/index.ts',
+		},
 	},
 	webpack: (config) => {
 		config.resolve.alias = {


### PR DESCRIPTION
## Summary

`npm run dev:admin` currently fails on a clean checkout with:

```text
Module not found: Can't resolve '@octafuse/core'
```

The root import is aliased to `packages/core/src/index.ts` in the webpack config, but Next 16 builds with Turbopack by default, so that alias is never applied. Turbopack then follows the package's `node` export and looks for `packages/core/dist/index.js`, which does not exist until core has been built.

This adds the equivalent alias to `turbopack.resolveAlias`. The target is relative to `packages/admin`; using the existing absolute path makes Turbopack treat it as a server-relative import.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation only
- [ ] Build / CI / chore

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md), including the contribution license terms.
- [x] No user-facing behavior or API docs are affected.
- [x] I ran the relevant checks locally.

## Verification

- `npm run build -w @octafuse/admin`
- `npm run dev:admin` (OpenNext preview reached `Ready on http://localhost:8789`)
- Confirmed `packages/core/dist/index.js` was absent during both checks.

## Related issues

None.