### PR TITLE
chore(release): prepare v2.1.2 with structured release notes

### DIFF
--- a/.changeset/README.md
+++ b/.changeset/README.md
@@ -12,7 +12,9 @@
 npx changeset
 ```
 
-按提示选择 **major / minor / patch**，并写一句摘要。会生成 `.changeset/<随机名>.md`，随 PR 提交即可。
+按提示选择 **major / minor / patch**，并写摘要。会生成 `.changeset/<随机名>.md`，随 PR 提交即可。
+
+文案建议：首段一句话摘要 + `### Proxy` / `### Admin` 等分区列表（见 [release-versioning.md](../docs/maintainers/release-versioning.md) §维护者日常操作）。GitHub Release 由 `npm run release:notes` 渲染，勿指望原始 `Patch Changes` 格式直接作为对外说明。
 
 ## 发版流程（自动化）
 

--- a/.changeset/admin-ux-route-logs.md
+++ b/.changeset/admin-ux-route-logs.md
@@ -1,0 +1,28 @@
+---
+"octafuse": patch
+"@octafuse/core": patch
+"@octafuse/tool-engines": patch
+"@octafuse/proxy": patch
+"@octafuse/admin": patch
+---
+
+优化 Admin 路由与 Provider 体验，请求日志补充外部系统字段，并修复干净仓库下 Admin 本地开发（Turbopack）无法解析 core 源码的问题。
+
+### Admin
+
+- **路由列表 / 拓扑**：同优先级内按状态、权重与名称稳定排序；因子状态芯片与无障碍文案完善。
+- **路由详情**：自定义参数展示与 tooltip；布局响应式调整。
+- **Provider 卡片**：布局与按钮交互优化；移除未使用的 endpoint 复制入口。
+- **请求日志**：补充展示 `external_system`，便于区分外部系统来源。
+- **本地开发**：修复 Turbopack 下 `@octafuse/core` 源码解析，干净 checkout 可运行 `dev:admin`。
+
+### Core
+
+- **请求日志**：读写路径补充 `external_system` 字段（D1 / Postgres / MySQL）。
+
+### 升级说明
+
+- 数据库迁移：无
+- 配置变更：无
+- 兼容性影响：无（纯增量字段与 Admin UX）
+- 建议操作：更新 proxy / admin / migrate 三镜像后滚动重启

--- a/.cursor/rules/release-notes.mdc
+++ b/.cursor/rules/release-notes.mdc
@@ -1,0 +1,72 @@
+---
+description: Octafuse Gateway GitHub Release notes 结构与 Changesets 文案约定
+globs: CHANGELOG.md,.changeset/**/*,.github/workflows/octafuse-docker-images.yml,scripts/release/**/*,docs/maintainers/release-versioning.md
+alwaysApply: false
+---
+
+# Release notes 约定
+
+GitHub Release 面向运维与集成方；`CHANGELOG.md` 保留 Changesets 开发追踪信息。二者分层，**不要**把原始 `### Patch Changes` + commit/`Thanks @` 原样当作公开发布说明。
+
+## GitHub Release 正文结构（固定顺序）
+
+```markdown
+## 本次更新
+
+一句话概括本版本解决了什么问题、带来什么价值。
+
+## 变更内容
+
+### Proxy
+- **能力名称**：用户可感知的变化。
+
+### Admin
+- **能力名称**：用户可感知的变化。
+
+### 文档
+- …
+
+## 升级说明
+
+- 数据库迁移：无
+- 配置变更：无
+- 兼容性影响：无
+- 建议操作：更新 proxy / admin / migrate 三镜像后滚动重启
+
+<details>
+<summary><strong>容器镜像与 SHA256 digest</strong></summary>
+
+### Proxy
+- 镜像：`ghcr.io/...-proxy:vX.Y.Z`
+- Digest：`sha256:...`
+
+### Admin
+- 镜像：`ghcr.io/...-admin:vX.Y.Z`
+- Digest：`sha256:...`
+
+### Migrate
+- 镜像：`ghcr.io/...-migrate:vX.Y.Z`
+- Digest：`sha256:...`
+
+</details>
+
+## 相关链接
+
+- [完整代码差异](https://github.com/OctaFuse/octafuse-gateway/compare/vA.B.C...vX.Y.Z)
+- [完整 CHANGELOG](https://github.com/OctaFuse/octafuse-gateway/blob/vX.Y.Z/CHANGELOG.md)
+```
+
+## 内容规则
+
+1. **不要**在 Release 首屏展示 `Patch Changes` / `Minor Changes` / `Major Changes`。
+2. **不要**在变更条目前缀提交哈希或 `Thanks @…`（可放在相关链接或留给 CHANGELOG）。
+3. 每条只表达一个变化：`**能力名称**：用户可感知的变化。`
+4. changeset 正文：首段为「本次更新」摘要；随后用 `### Proxy` / `### Admin` / `### 文档` / `### Core` 等分区；需要时加 `### 升级说明`。
+5. 避免在单个 changeset 列表项内部再嵌套会破坏 Markdown 列表的标题层级；分区标题写在摘要段之后、列表之前。
+6. 语言与标题统一中文语境；Release 标题形如 `OctaFuse vX.Y.Z`。
+7. Digest 默认放在 `<details>` 折叠区；镜像 tag 与 digest 一并给出。
+
+## 工具
+
+- 渲染：`npm run release:notes -- --version X.Y.Z`（`scripts/release/render-release-notes.mjs`）
+- CI：`octafuse-docker-images.yml` 在 tag 发版路径调用同一脚本写入 GitHub Release

--- a/.github/workflows/octafuse-docker-images.yml
+++ b/.github/workflows/octafuse-docker-images.yml
@@ -209,12 +209,14 @@ jobs:
     permissions:
       contents: write
     steps:
-      - name: Checkout (CHANGELOG only)
+      - name: Checkout (release note sources)
         uses: actions/checkout@v4
         with:
           ref: ${{ github.ref }}
           sparse-checkout: |
             CHANGELOG.md
+            docs/releases
+            scripts/release/render-release-notes.mjs
           sparse-checkout-cone-mode: false
 
       - name: Download digest artifacts
@@ -230,46 +232,25 @@ jobs:
           OWNER_REPO_LC=$(echo '${{ github.repository }}' | tr '[:upper:]' '[:lower:]')
           TAG="${{ github.ref_name }}"
           VERSION="${TAG#v}"
-          awk -v ver="$VERSION" '
-            $0 ~ "^## " ver "$" {flag=1; next}
-            flag && /^## / {exit}
-            flag {print}
-          ' CHANGELOG.md > changelog-section.md || true
-          if [ ! -s changelog-section.md ]; then
-            echo "_(CHANGELOG 中未找到 \`## ${VERSION}\` 段落；请核对 Version PR 是否更新了 CHANGELOG。)_" > changelog-section.md
-          fi
           resolve_digest_file() {
             local s="$1"
             find digest-artifacts -name "${s}.digest" -type f 2>/dev/null | head -1
           }
-          {
-            echo "## What's changed"
-            echo ""
-            cat changelog-section.md
-            echo ""
-            echo "---"
-            echo ""
-            echo "## Container images (GHCR)"
-            echo ""
-            echo "Tag **${TAG}** — multi-arch manifest digests (proxy / admin / migrate):"
-            echo ""
-            for s in proxy admin migrate; do
-              f=$(resolve_digest_file "$s")
-              if [ -n "$f" ] && [ -f "$f" ]; then
-                d=$(tr -d '\n\r' < "$f")
-                echo "- **${s}**: \`${d}\`"
-                echo "  - \`ghcr.io/${OWNER_REPO_LC}-${s}@${d}\`"
-              else
-                echo "- **${s}**: _(digest artifact missing)_"
-              fi
-            done
-            echo ""
-            echo "Pull by digest for reproducible deploys, or by tag \`${TAG}\` after verifying digest."
-            echo ""
-            echo "---"
-            echo ""
-            echo "Release process: [.changeset/README.md](.changeset/README.md) · [docs/maintainers/release-versioning.md](docs/maintainers/release-versioning.md)"
-          } > release-notes.md
+          cmd=(
+            node scripts/release/render-release-notes.mjs
+            --version "${VERSION}"
+            --repo "${{ github.repository }}"
+            --owner-repo-lc "${OWNER_REPO_LC}"
+            --out release-notes.md
+          )
+          for s in proxy admin migrate; do
+            f=$(resolve_digest_file "$s")
+            if [ -n "$f" ] && [ -f "$f" ]; then
+              d=$(tr -d '\n\r' < "$f")
+              cmd+=(--digest "${s}=${d}")
+            fi
+          done
+          "${cmd[@]}"
           cat release-notes.md >> "$GITHUB_STEP_SUMMARY"
 
       - name: Create or update GitHub Release
@@ -281,5 +262,5 @@ jobs:
           if gh release view "$TAG" --repo "${{ github.repository }}" 2>/dev/null; then
             gh release edit "$TAG" --repo "${{ github.repository }}" --notes-file release-notes.md
           else
-            gh release create "$TAG" --repo "${{ github.repository }}" --title "Octafuse ${TAG}" --notes-file release-notes.md
+            gh release create "$TAG" --repo "${{ github.repository }}" --title "OctaFuse ${TAG}" --notes-file release-notes.md
           fi

--- a/docs/maintainers/release-versioning.md
+++ b/docs/maintainers/release-versioning.md
@@ -49,7 +49,7 @@ flowchart LR
 
 2. **`.github/workflows/octafuse-docker-images.yml`**（**`push` → `tags/v*`**，或由 Release **dispatch**；或 **`workflow_dispatch`**）  
    - 构建并推送 **GHCR** 三镜像。  
-   - 在 **tag 发版**路径下创建/更新 **GitHub Release**：正文含 **`CHANGELOG.md` 中对应 `## X.Y.Z` 段落**（What's changed）与各镜像 **digest**。
+   - 在 **tag 发版**路径下创建/更新 **GitHub Release**：正文由 **`npm run release:notes`**（`scripts/release/render-release-notes.mjs`）生成——**本次更新 / 变更内容 / 升级说明** + 折叠区 **镜像 digest** + 相关链接；优先读取可选覆盖文件 **`docs/releases/X.Y.Z.md`**，否则从 **`CHANGELOG.md`** 对应段落规范化（去掉 `Patch Changes` 与 commit/`Thanks @` 前缀）。
 
 3. **`.github/workflows/verify-package-versions.yml`**  
    - PR / `main` / `v*` 标签上校验：根与 workspace **`version` 一致**；在 **tag** 上校验 **`v` + version** 与标签名一致。
@@ -112,6 +112,21 @@ npx changeset
 
 选择 **patch / minor / major**，提交生成的 `.changeset/<id>.md`。
 
+**changeset 文案（供 GitHub Release 渲染）**：
+
+1. **首段**：一句话「本次更新」摘要（面向运维 / 集成方）。  
+2. **分区**：用 `### Proxy` / `### Admin` / `### Core` / `### 文档` 等列出变更；每条 `**能力名称**：用户可感知的变化。`  
+3. **可选** `### 升级说明`：有迁移 / 配置 / 破坏性时必写；缺省时 Release 渲染为「迁移/配置/兼容性：无」。  
+4. **不要**依赖 `### Patch Changes` 或 commit/`Thanks @` 出现在公开发布首屏——这些由 Changesets 写入 `CHANGELOG.md`，Release 脚本会剥离。
+
+本地预览（Version PR 合并、`CHANGELOG` 已有 `## X.Y.Z` 之后）：
+
+```bash
+npm run release:notes -- --version X.Y.Z
+```
+
+需要完全手写某版本正文时，可新增 **`docs/releases/X.Y.Z.md`**（含 `## 本次更新` / `## 变更内容` / `## 升级说明`），CI 会优先使用。
+
 ### 2. 生成版本 PR
 
 合并上述 PR 到 **`main`** 后，**Release** workflow 会创建 **Version Packages** PR。**维护者审核 diff**（版本号、`CHANGELOG.md`）后合并。
@@ -146,3 +161,5 @@ npx changeset
 - [docker.md](../operators/deployment/docker.md) — GHCR 与 Compose  
 - [CHANGELOG.md](../../CHANGELOG.md) — 聚合变更记录  
 - [`.changeset/README.md`](../../.changeset/README.md) — Changesets 快速说明  
+- [`docs/releases/`](../releases/) — 可选：某版本 GitHub Release 正文覆盖（如 `2.1.2.md`）  
+- `npm run release:notes -- --version X.Y.Z` — 本地预览 Release 正文  

--- a/docs/releases/2.1.2.md
+++ b/docs/releases/2.1.2.md
@@ -1,0 +1,24 @@
+## 本次更新
+
+优化 Admin 路由与 Provider 体验，请求日志补充外部系统字段，并修复干净仓库下 Admin 本地开发（Turbopack）无法解析 core 源码的问题。
+
+## 变更内容
+
+### Admin
+
+- **路由列表 / 拓扑**：同优先级内按状态、权重与名称稳定排序；因子状态芯片与无障碍文案完善。
+- **路由详情**：自定义参数展示与 tooltip；布局响应式调整。
+- **Provider 卡片**：布局与按钮交互优化；移除未使用的 endpoint 复制入口。
+- **请求日志**：补充展示 `external_system`，便于区分外部系统来源。
+- **本地开发**：修复 Turbopack 下 `@octafuse/core` 源码解析，干净 checkout 可运行 `dev:admin`。
+
+### Core
+
+- **请求日志**：读写路径补充 `external_system` 字段（D1 / Postgres / MySQL）。
+
+## 升级说明
+
+- 数据库迁移：无
+- 配置变更：无
+- 兼容性影响：无（纯增量字段与 Admin UX）
+- 建议操作：更新 proxy / admin / migrate 三镜像后滚动重启

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
 		"gen:wrangler": "node scripts/deploy/gen-wrangler.mjs",
 		"verify:package-versions": "node scripts/ci/verify-package-versions.mjs",
 		"ci:changeset-tag-push": "changeset tag && node scripts/ci/push-root-release-tag.mjs",
+		"release:notes": "node scripts/release/render-release-notes.mjs",
 		"dev:proxy": "npm run dev -w @octafuse/proxy",
 		"dev:proxy:node": "dotenv -c -- npm run dev:node -w @octafuse/proxy",
 		"dev:admin": "npm run preview -w @octafuse/admin",

--- a/scripts/release/render-release-notes.mjs
+++ b/scripts/release/render-release-notes.mjs
@@ -1,0 +1,321 @@
+#!/usr/bin/env node
+/**
+ * Build GitHub Release notes from CHANGELOG.md (Changesets output) + image digests.
+ *
+ * Usage:
+ *   node scripts/release/render-release-notes.mjs --version 2.1.2
+ *   node scripts/release/render-release-notes.mjs --version 2.1.2 \
+ *     --digest proxy=sha256:… --digest admin=sha256:… --digest migrate=sha256:… \
+ *     --out release-notes.md
+ *
+ * Optional override: docs/releases/X.Y.Z.md (full body for 本次更新 + 变更内容 + 升级说明;
+ * digests / 相关链接 still appended by this script).
+ */
+import { readFileSync, writeFileSync, existsSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const root = join(__dirname, "../..");
+const DEFAULT_REPO = "OctaFuse/octafuse-gateway";
+
+function parseArgs(argv) {
+	const out = {
+		version: "",
+		changelog: join(root, "CHANGELOG.md"),
+		out: "",
+		repo: DEFAULT_REPO,
+		prevTag: "",
+		digests: /** @type {Record<string, string>} */ ({}),
+		ownerRepoLc: "",
+	};
+	for (let i = 0; i < argv.length; i++) {
+		const a = argv[i];
+		if (a === "--version") out.version = argv[++i] ?? "";
+		else if (a === "--changelog") out.changelog = resolve(argv[++i] ?? "");
+		else if (a === "--out") out.out = resolve(argv[++i] ?? "");
+		else if (a === "--repo") out.repo = argv[++i] ?? DEFAULT_REPO;
+		else if (a === "--prev-tag") out.prevTag = argv[++i] ?? "";
+		else if (a === "--owner-repo-lc") out.ownerRepoLc = argv[++i] ?? "";
+		else if (a === "--digest") {
+			const raw = argv[++i] ?? "";
+			const eq = raw.indexOf("=");
+			if (eq <= 0) throw new Error(`Invalid --digest ${raw} (expect name=sha256:…)`);
+			out.digests[raw.slice(0, eq)] = raw.slice(eq + 1).trim();
+		} else if (a === "--help" || a === "-h") {
+			out.help = true;
+		} else {
+			throw new Error(`Unknown argument: ${a}`);
+		}
+	}
+	return out;
+}
+
+/** @param {string} changelog @param {string} version */
+function extractChangelogSection(changelog, version) {
+	const lines = changelog.split(/\r?\n/);
+	const start = lines.findIndex((l) => l === `## ${version}`);
+	if (start < 0) return null;
+	const body = [];
+	for (let i = start + 1; i < lines.length; i++) {
+		if (/^## /.test(lines[i])) break;
+		body.push(lines[i]);
+	}
+	return body.join("\n").replace(/^\n+/, "").replace(/\n+$/, "");
+}
+
+/** Strip Changesets wrappers: Patch/Minor/Major headers + commit/Thanks prefixes. */
+function normalizeChangesetBody(section) {
+	let text = section
+		.replace(/^### (Patch|Minor|Major) Changes\s*\n+/gm, "")
+		.trim();
+
+	// Changesets GitHub changelog: "- [`hash`](url) Thanks [@user](url)! - rest"
+	// (backticks wrap the commit markdown link; optional PR link may precede)
+	text = text.replace(/^- .+?Thanks \[@[^\]]+\]\([^)]+\)! - /gm, "- ");
+
+	// Unindent one level of content that Changesets nests under the bullet
+	// (common pattern: blank line then "  ### Section" / "  - item")
+	const lines = text.split("\n");
+	const out = [];
+	let inNested = false;
+	for (const line of lines) {
+		if (/^- /.test(line)) {
+			inNested = true;
+			const rest = line.slice(2);
+			// If the bullet is only a heading or starts a section, promote it
+			if (/^#{2,4}\s/.test(rest)) {
+				out.push(rest);
+			} else if (rest.trim() === "") {
+				out.push("");
+			} else {
+				out.push(rest);
+			}
+			continue;
+		}
+		if (line.trim() === "") {
+			out.push("");
+			continue;
+		}
+		if (inNested && /^  /.test(line)) {
+			out.push(line.slice(2));
+			continue;
+		}
+		inNested = false;
+		out.push(line);
+	}
+	return out.join("\n").replace(/\n{3,}/g, "\n\n").trim();
+}
+
+/**
+ * Split normalized body into summary / sections / upgrade notes.
+ * @param {string} body
+ */
+function splitReleaseParts(body) {
+	const upgradeMatch = body.match(/\n### 升级说明\n([\s\S]*?)(?=\n### |\s*$)/);
+	let withoutUpgrade = body;
+	let upgrade = "";
+	if (upgradeMatch) {
+		upgrade = upgradeMatch[1].trim();
+		withoutUpgrade = (body.slice(0, upgradeMatch.index) + body.slice(upgradeMatch.index + upgradeMatch[0].length)).trim();
+	}
+
+	const firstHeading = withoutUpgrade.search(/\n### /);
+	let summary = "";
+	let changes = withoutUpgrade;
+	if (firstHeading >= 0) {
+		summary = withoutUpgrade.slice(0, firstHeading).trim();
+		changes = withoutUpgrade.slice(firstHeading + 1).trim(); // drop leading \n
+	} else {
+		// No ### sections: treat whole body as 变更内容 bullets / prose
+		summary = "";
+		changes = withoutUpgrade;
+	}
+
+	// If summary accidentally starts with a list-only leftover, keep empty
+	if (/^### /.test(summary)) {
+		changes = `${summary}\n\n${changes}`.trim();
+		summary = "";
+	}
+
+	return { summary, changes, upgrade };
+}
+
+function defaultUpgradeNotes() {
+	return [
+		"- 数据库迁移：无",
+		"- 配置变更：无",
+		"- 兼容性影响：无",
+		"- 建议操作：更新 proxy / admin / migrate 三镜像后滚动重启",
+	].join("\n");
+}
+
+function defaultSummary(version) {
+	return `OctaFuse Gateway **v${version}**。`;
+}
+
+/**
+ * @param {object} opts
+ * @param {string} opts.version
+ * @param {string} opts.summary
+ * @param {string} opts.changes
+ * @param {string} opts.upgrade
+ * @param {Record<string, string>} opts.digests
+ * @param {string} opts.repo
+ * @param {string} opts.prevTag
+ * @param {string} opts.ownerRepoLc
+ */
+function renderNotes(opts) {
+	const tag = `v${opts.version}`;
+	const repoLc =
+		opts.ownerRepoLc ||
+		opts.repo.toLowerCase();
+	const prev = opts.prevTag || "";
+	const compare =
+		prev.length > 0
+			? `https://github.com/${opts.repo}/compare/${prev}...${tag}`
+			: `https://github.com/${opts.repo}/releases/tag/${tag}`;
+
+	const lines = [];
+	lines.push("## 本次更新");
+	lines.push("");
+	lines.push(opts.summary || defaultSummary(opts.version));
+	lines.push("");
+	lines.push("## 变更内容");
+	lines.push("");
+	lines.push(opts.changes || "_(无 CHANGELOG 段落；请核对 Version PR。)_");
+	lines.push("");
+	lines.push("## 升级说明");
+	lines.push("");
+	lines.push(opts.upgrade || defaultUpgradeNotes());
+	lines.push("");
+	lines.push("<details>");
+	lines.push("<summary><strong>容器镜像与 SHA256 digest</strong></summary>");
+	lines.push("");
+	lines.push(`Tag **${tag}** — multi-arch manifest digests：`);
+	lines.push("");
+	for (const name of ["proxy", "admin", "migrate"]) {
+		const d = opts.digests[name];
+		lines.push(`### ${name[0].toUpperCase()}${name.slice(1)}`);
+		lines.push("");
+		lines.push(`- 镜像：\`ghcr.io/${repoLc}-${name}:${tag}\``);
+		if (d) {
+			lines.push(`- Digest：\`${d}\``);
+			lines.push(`- 固定拉取：\`ghcr.io/${repoLc}-${name}@${d}\``);
+		} else {
+			lines.push("- Digest：_(缺失)_");
+		}
+		lines.push("");
+	}
+	lines.push("可按 digest 做可复现部署，或在核对 digest 后使用 tag。");
+	lines.push("");
+	lines.push("</details>");
+	lines.push("");
+	lines.push("## 相关链接");
+	lines.push("");
+	lines.push(`- [完整代码差异](${compare})`);
+	lines.push(
+		`- [完整 CHANGELOG](https://github.com/${opts.repo}/blob/${tag}/CHANGELOG.md)`,
+	);
+	lines.push(
+		`- [发版流程](https://github.com/${opts.repo}/blob/${tag}/docs/maintainers/release-versioning.md)`,
+	);
+	lines.push("");
+	return lines.join("\n");
+}
+
+function guessPrevTag(changelog, version) {
+	const lines = changelog.split(/\r?\n/);
+	const start = lines.findIndex((l) => l === `## ${version}`);
+	if (start < 0) return "";
+	for (let i = start + 1; i < lines.length; i++) {
+		const m = lines[i].match(/^## (\d+\.\d+\.\d+(?:-[\w.]+)?)\s*$/);
+		if (m) return `v${m[1]}`;
+	}
+	return "";
+}
+
+function main() {
+	const args = parseArgs(process.argv.slice(2));
+	if (args.help || !args.version) {
+		console.log(`Usage: node scripts/release/render-release-notes.mjs --version X.Y.Z [options]
+
+Options:
+  --changelog PATH       Default: ./CHANGELOG.md
+  --out PATH             Write notes to file (default: stdout)
+  --repo OWNER/NAME      Default: ${DEFAULT_REPO}
+  --prev-tag vX.Y.Z      Compare link base (default: previous ## in CHANGELOG)
+  --owner-repo-lc name   GHCR image prefix (default: lowercased --repo)
+  --digest name=sha256:… Repeatable for proxy / admin / migrate
+`);
+		process.exit(args.help ? 0 : 1);
+	}
+
+	const overridePath = join(root, "docs", "releases", `${args.version}.md`);
+	let summary = "";
+	let changes = "";
+	let upgrade = "";
+
+	if (existsSync(overridePath)) {
+		const override = readFileSync(overridePath, "utf8").trim();
+		const parts = splitReleaseParts(
+			override
+				.replace(/^## 本次更新\s*\n+/m, "")
+				.replace(/^## 变更内容\s*\n+/m, "### __CHANGES_ANCHOR__\n")
+				.replace(/^## 升级说明\s*\n+/m, "### 升级说明\n"),
+		);
+		// If override used ## headings already, re-parse more simply:
+		const raw = readFileSync(overridePath, "utf8");
+		const sumM = raw.match(/## 本次更新\s*\n+([\s\S]*?)(?=\n## |\s*$)/);
+		const chM = raw.match(/## 变更内容\s*\n+([\s\S]*?)(?=\n## |\s*$)/);
+		const upM = raw.match(/## 升级说明\s*\n+([\s\S]*?)(?=\n## |\s*$)/);
+		if (sumM || chM) {
+			summary = (sumM?.[1] ?? "").trim();
+			changes = (chM?.[1] ?? "").trim();
+			upgrade = (upM?.[1] ?? "").trim();
+		} else {
+			({ summary, changes, upgrade } = parts);
+			if (changes.startsWith("### __CHANGES_ANCHOR__")) {
+				changes = changes.replace(/^### __CHANGES_ANCHOR__\n*/, "").trim();
+			}
+		}
+	} else {
+		const changelog = readFileSync(args.changelog, "utf8");
+		const section = extractChangelogSection(changelog, args.version);
+		if (!section) {
+			summary = defaultSummary(args.version);
+			changes = `_(CHANGELOG 中未找到 \`## ${args.version}\` 段落；请核对 Version PR 是否更新了 CHANGELOG。)_`;
+		} else {
+			const normalized = normalizeChangesetBody(section);
+			({ summary, changes, upgrade } = splitReleaseParts(normalized));
+		}
+		if (!args.prevTag) {
+			args.prevTag = guessPrevTag(readFileSync(args.changelog, "utf8"), args.version);
+		}
+	}
+
+	if (!args.prevTag && existsSync(args.changelog)) {
+		args.prevTag = guessPrevTag(readFileSync(args.changelog, "utf8"), args.version);
+	}
+
+	const notes = renderNotes({
+		version: args.version,
+		summary,
+		changes,
+		upgrade,
+		digests: args.digests,
+		repo: args.repo,
+		prevTag: args.prevTag,
+		ownerRepoLc: args.ownerRepoLc,
+	});
+
+	if (args.out) {
+		writeFileSync(args.out, notes, "utf8");
+		console.error(`Wrote ${args.out}`);
+	} else {
+		process.stdout.write(notes);
+		if (!notes.endsWith("\n")) process.stdout.write("\n");
+	}
+}
+
+main();


### PR DESCRIPTION
## Summary
- 为 GitHub Release 落地结构化正文：`本次更新` / `变更内容` / `升级说明` + 折叠区镜像 digest + 相关链接（`scripts/release/render-release-notes.mjs`，`npm run release:notes`）
- 新增 patch changeset，覆盖 v2.1.1 之后的 Admin UX、路由排序/因子展示、请求日志 `external_system`、Turbopack core 解析修复
- 提供 `docs/releases/2.1.2.md` 覆盖稿，确保本版 Release 不回落到杂乱的 Changesets 原始片段

## Test plan
- [ ] 合并本 PR 后确认 Release workflow 打开 **chore: version packages**（版本 bump 到 2.1.2）
- [ ] 审核 Version Packages PR 中的 `CHANGELOG.md` / 四包 `version`
- [ ] 本地预览：`npm run release:notes -- --version 2.1.2 --prev-tag v2.1.1`
- [ ] 合并 Version PR 后确认打出 `v2.1.2`、Docker Images 成功、GitHub Release 使用新结构


Made with [Cursor](https://cursor.com)