### PR TITLE
chore(release): prepare v2.4.0

### DIFF
--- a/.changeset/release-2-4-0.md
+++ b/.changeset/release-2-4-0.md
@@ -1,0 +1,38 @@
+---
+"octafuse": minor
+---
+
+OctaFuse Gateway v2.4.0 新增 DashScope 原生 ASR/TTS 与实时音频能力，并将 Admin 认证从单一 `MASTER_KEY` 升级为具名 Admin API Keys；Routes Flow 粘滞运维体验同步增强。
+
+### Proxy
+
+- **DashScope 音频路由**：支持经 OpenAI 兼容面或 DashScope 原生协议调用文件 ASR / TTS，并按适配器转发至百炼上游。
+- **DashScope Realtime**：新增 `GET /v1/dashscope/realtime` WebSocket 入口，透传原生实时 ASR / TTS 事件；Node 运行时补齐 realtime 代理。
+- **音频计费字符**：请求日志新增 `audio_characters`，TTS 按上游有效计费字符独立记账。
+
+### Admin
+
+- **Admin API Keys**：控制台支持具名集成密钥的创建、轮换、吊销与权限；浏览器会话与 Bearer Key 身份分离，Access Keys 管理仅 Console Session 可写。
+- **DashScope 预设与联调**：Qwen Token Plan / Provider 导入增加 DashScope 音频端点与 ASR/TTS 模型目录；Playground 支持 DashScope realtime 联调；路由列表隐藏上游端点噪音展示。
+- **粘滞运维 UX**：Routes Flow 增强粘滞绑定摘要、刷新、用户数与拓扑默认密度等运维可视能力。
+- **阿里云 TTS 定价**：修正 Aliyun TTS 单价，并补充 CosyVoice 3.5 预设。
+
+### Core
+
+- **迁移 0022**：`api_key_request_logs` 增加 `audio_characters`（D1 / Postgres / MySQL）。
+- **迁移 0023**：新增 `admin_api_keys` / `admin_sessions`，并将历史 `system_config.MASTER_KEY` 复制为全权限 Key `legacy-master`。
+- **迁移 0024**：删除遗留 `system_config.MASTER_KEY` 配置行。
+- **迁移 0025**：为 `user_audit_logs(actor_id, created_at)` 增加检索索引。
+
+### 文档
+
+- **DashScope 音频架构**：新增 [dashscope-audio.md](./docs/developers/architecture/dashscope-audio.md)。
+- **Admin 认证**：更新 Admin API / Cloudflare 部署说明中的具名 Key 与 `legacy-master` 轮换指引。
+
+### 升级说明
+
+- **数据库迁移**：必须应用 **0022**–**0025**；三种数据库语义一致。
+- **发布顺序**：维护窗口内先备份 → 执行迁移 → 立即部署同一版本的 Proxy / Admin / migrate；禁止新旧版本混跑（尤其 0023/0024 认证切换）。
+- **配置变更**：部署后尽快在 **系统集成 → 集成密钥** 为外部系统创建最小权限 Key，更新其 `GATEWAY_MASTER_KEY`（或等价变量），再轮换/吊销 `legacy-master`；Bearer Key（含 `*`）不可管理 `/admin/access-keys/*`。
+- **兼容性影响**：客户端推理 URL 不变；旧 `MASTER_KEY` 值在迁移后仍可通过 `legacy-master` 调用 Admin API，直至吊销。
+- **建议操作**：验证 Admin 登录、具名 Key 权限、DashScope ASR/TTS/realtime 冒烟，以及 chat / messages / gemini / images 既有协议回归。

--- a/.cursor/rules/release-notes.mdc
+++ b/.cursor/rules/release-notes.mdc
@@ -54,6 +54,10 @@ GitHub Release 面向运维与集成方；`CHANGELOG.md` 保留 Changesets 开�
 
 - [完整代码差异](https://github.com/OctaFuse/octafuse-gateway/compare/vA.B.C...vX.Y.Z)
 - [完整 CHANGELOG](https://github.com/OctaFuse/octafuse-gateway/blob/vX.Y.Z/CHANGELOG.md)
+
+## 致谢
+
+（仅当本版本有外部贡献者时；放在 release notes 最底部。`docs/releases/X.Y.Z.md` 可写 `## 致谢`，渲染脚本会保留到相关链接之后。）
 ```
 
 ## 内容规则
@@ -65,6 +69,7 @@ GitHub Release 面向运维与集成方；`CHANGELOG.md` 保留 Changesets 开�
 5. 避免在单个 changeset 列表项内部再嵌套会破坏 Markdown 列表的标题层级；分区标题写在摘要段之后、列表之前。
 6. 语言与标题统一中文语境；Release 标题形如 `OctaFuse vX.Y.Z`。
 7. Digest 默认放在 `<details>` 折叠区；镜像 tag 与 digest 一并给出。
+8. 若本版本有外部贡献者：在 `docs/releases/X.Y.Z.md` 增加 `## 致谢`（GitHub @login + PR 链接），渲染后位于正文最底部。
 
 ## 工具
 

--- a/docs/releases/2.4.0.md
+++ b/docs/releases/2.4.0.md
@@ -1,0 +1,42 @@
+## 本次更新
+
+新增 DashScope 原生 ASR/TTS 与实时音频能力，并将 Admin 认证从单一 `MASTER_KEY` 升级为具名 Admin API Keys；Routes Flow 粘滞运维体验同步增强。
+
+## 变更内容
+
+### Proxy
+
+- **DashScope 音频路由**：支持经 OpenAI 兼容面或 DashScope 原生协议调用文件 ASR / TTS，并按适配器转发至百炼上游。
+- **DashScope Realtime**：新增 `GET /v1/dashscope/realtime` WebSocket 入口，透传原生实时 ASR / TTS 事件；Node 运行时补齐 realtime 代理。
+- **音频计费字符**：请求日志新增 `audio_characters`，TTS 按上游有效计费字符独立记账。
+
+### Admin
+
+- **Admin API Keys**：控制台支持具名集成密钥的创建、轮换、吊销与权限；浏览器会话与 Bearer Key 身份分离，Access Keys 管理仅 Console Session 可写。
+- **DashScope 预设与联调**：Qwen Token Plan / Provider 导入增加 DashScope 音频端点与 ASR/TTS 模型目录；Playground 支持 DashScope realtime 联调；路由列表隐藏上游端点噪音展示。
+- **粘滞运维 UX**：Routes Flow 增强粘滞绑定摘要、刷新、用户数与拓扑默认密度等运维可视能力。
+- **阿里云 TTS 定价**：修正 Aliyun TTS 单价，并补充 CosyVoice 3.5 预设。
+
+### Core
+
+- **迁移 0022**：`api_key_request_logs` 增加 `audio_characters`（D1 / Postgres / MySQL）。
+- **迁移 0023**：新增 `admin_api_keys` / `admin_sessions`，并将历史 `system_config.MASTER_KEY` 复制为全权限 Key `legacy-master`。
+- **迁移 0024**：删除遗留 `system_config.MASTER_KEY` 配置行。
+- **迁移 0025**：为 `user_audit_logs(actor_id, created_at)` 增加检索索引。
+
+### 文档
+
+- **DashScope 音频架构**：新增 `docs/developers/architecture/dashscope-audio.md`。
+- **Admin 认证**：更新 Admin API / Cloudflare 部署说明中的具名 Key 与 `legacy-master` 轮换指引。
+
+## 升级说明
+
+- 数据库迁移：必须应用 **0022**–**0025**；三种数据库语义一致
+- 发布顺序：维护窗口内先备份 → 执行迁移 → 立即部署同一版本的 Proxy / Admin / migrate；禁止新旧版本混跑（尤其 0023/0024 认证切换）
+- 配置变更：部署后尽快在 **系统集成 → 集成密钥** 为外部系统创建最小权限 Key，更新其 `GATEWAY_MASTER_KEY`（或等价变量），再轮换/吊销 `legacy-master`；Bearer Key（含 `*`）不可管理 `/admin/access-keys/*`
+- 兼容性影响：客户端推理 URL 不变；旧 `MASTER_KEY` 值在迁移后仍可通过 `legacy-master` 调用 Admin API，直至吊销
+- 建议操作：验证 Admin 登录、具名 Key 权限、DashScope ASR/TTS/realtime 冒烟，以及 chat / messages / gemini / images 既有协议回归
+
+## 致谢
+
+感谢外部贡献者 [@samchaolau](https://github.com/samchaolau) 通过 [#93](https://github.com/OctaFuse/octafuse-gateway/pull/93) 贡献 DashScope ASR/TTS 路由与实时音频能力。

--- a/scripts/release/render-release-notes.mjs
+++ b/scripts/release/render-release-notes.mjs
@@ -9,6 +9,7 @@
  *     --out release-notes.md
  *
  * Optional override: docs/releases/X.Y.Z.md (full body for 本次更新 + 变更内容 + 升级说明;
+ * optional ## 致谢 is preserved at the bottom after 相关链接;
  * digests / 相关链接 still appended by this script).
  */
 import { readFileSync, writeFileSync, existsSync } from "node:fs";
@@ -160,6 +161,7 @@ function defaultSummary(version) {
  * @param {string} opts.summary
  * @param {string} opts.changes
  * @param {string} opts.upgrade
+ * @param {string} [opts.acknowledgements]
  * @param {Record<string, string>} opts.digests
  * @param {string} opts.repo
  * @param {string} opts.prevTag
@@ -221,6 +223,12 @@ function renderNotes(opts) {
 		`- [发版流程](https://github.com/${opts.repo}/blob/${tag}/docs/maintainers/release-versioning.md)`,
 	);
 	lines.push("");
+	if (opts.acknowledgements?.trim()) {
+		lines.push("## 致谢");
+		lines.push("");
+		lines.push(opts.acknowledgements.trim());
+		lines.push("");
+	}
 	return lines.join("\n");
 }
 
@@ -255,6 +263,7 @@ Options:
 	let summary = "";
 	let changes = "";
 	let upgrade = "";
+	let acknowledgements = "";
 
 	if (existsSync(overridePath)) {
 		const override = readFileSync(overridePath, "utf8").trim();
@@ -269,15 +278,18 @@ Options:
 		const sumM = raw.match(/## 本次更新\s*\n+([\s\S]*?)(?=\n## |\s*$)/);
 		const chM = raw.match(/## 变更内容\s*\n+([\s\S]*?)(?=\n## |\s*$)/);
 		const upM = raw.match(/## 升级说明\s*\n+([\s\S]*?)(?=\n## |\s*$)/);
+		const ackM = raw.match(/## 致谢\s*\n+([\s\S]*?)(?=\n## |\s*$)/);
 		if (sumM || chM) {
 			summary = (sumM?.[1] ?? "").trim();
 			changes = (chM?.[1] ?? "").trim();
 			upgrade = (upM?.[1] ?? "").trim();
+			acknowledgements = (ackM?.[1] ?? "").trim();
 		} else {
 			({ summary, changes, upgrade } = parts);
 			if (changes.startsWith("### __CHANGES_ANCHOR__")) {
 				changes = changes.replace(/^### __CHANGES_ANCHOR__\n*/, "").trim();
 			}
+			acknowledgements = (ackM?.[1] ?? "").trim();
 		}
 	} else {
 		const changelog = readFileSync(args.changelog, "utf8");
@@ -303,6 +315,7 @@ Options:
 		summary,
 		changes,
 		upgrade,
+		acknowledgements,
 		digests: args.digests,
 		repo: args.repo,
 		prevTag: args.prevTag,


### PR DESCRIPTION
## Summary
- 为 `main` 上自 v2.3.0 以来的变更补齐 **minor** changeset，触发 Version Packages → `v2.4.0`
- 新增 `docs/releases/2.4.0.md`（含迁移 0022–0025 升级说明）
- Release notes 底部致谢外部贡献者 [@samchaolau](https://github.com/samchaolau)（[#93](https://github.com/OctaFuse/octafuse-gateway/pull/93)）
- `render-release-notes.mjs` 支持保留 `## 致谢` 至正文最底部

## Test plan
- [ ] 合并后 Release workflow 打开 Version Packages PR，版本号为 `2.4.0`
- [ ] 合并 Version PR 后打出 `v2.4.0` 并触发 Docker Images
- [ ] GitHub Release 正文含 digest，且底部有致谢段
- [ ] 将 `main` 同步回 `develop`


Made with [Cursor](https://cursor.com)