### PR TITLE
refactor(api): update image billing modes and usage charge logic

### DIFF
--- a/docs/developers/api/user.md
+++ b/docs/developers/api/user.md
@@ -915,10 +915,10 @@ Image 模型支持两种 `pricing_profile.image_billing_mode`（再乘路由 `ch
 | **`token`**（GPT Image / Gemini） | usage 分项 × `$/1M`（对齐 [OpenAI Image Cost](https://platform.openai.com/docs/guides/image-generation)） | `image_tokens` |
 | **`per_image`**（Seedream / GLM / Grok） | `output_unit × 确认输出张数 + input_unit × 参考图数` | `image_per_image` |
 
-1. **预检额度**：token 模式用 quality×size **估算** tokens；per_image 模式用请求张数 × 单价；均取全候选路由最高 `charged_factor`
+1. **预检额度**：token 模式用 quality×size **估算** tokens；per_image 模式用请求张数 × 单价；均取全候选路由最高 `charged_factor`。预检只决定能不能打上游，**不**等于最终扣费
 2. **成功出图**：token 按 **`usage` 真实分项**；per_image 按 **有效返回图片数**（忽略 usage tokens）
-3. **客户端取消 / Gateway 超时**（请求已发出）：默认按入口预检扣费（防亏损）；per_image 可用 `uncertain_result_policy=zero` 覆盖；合成 504 **不** failover
-4. **明确上游错误且未发出 / 空结果**：零费用日志
+3. **客户端取消 / Gateway 超时**（请求已发出，合成 504）：token / per_image **均零费用**。合成 504 **不** failover
+4. **明确上游 4xx/5xx、网络合成 502、空结果**：零费用日志
 5. Request log **不**保存 prompt 原文、参考图或 Base64；列含 `billing_kind`、`input_image_count`、`output_image_count`；`raw_usage` / `pricing_audit` 供审计
 6. 须配置对应模式目录价；无合法 mode/价格则不计费。详见 [image-models.md](../reference/image-models.md)
 
@@ -947,11 +947,12 @@ Image 模型支持两种 `pricing_profile.image_billing_mode`（再乘路由 `ch
 {
   "image_billing_mode": "per_image",
   "image": {
-    "default": 0.22,
-    "uncertain_result_policy": "requested"
+    "default": 0.22
   }
 }
 ```
+
+`uncertain_result_policy` 仍可写入 profile，但取消 / 超时不再按它扣费。
 
 Admin 中为图片模型配置 `output_modalities: ["image"]` 及对应 mode 价目即可。
 

--- a/docs/developers/reference/image-models.md
+++ b/docs/developers/reference/image-models.md
@@ -163,8 +163,8 @@ charged ≈
 | 规则 | 行为 |
 |------|------|
 | 成功出图 | 按响应 `usage` 真实分项扣费 |
-| 客户端取消 / Gateway 超时（已发出） | 按入口 token 预检扣费（防亏损） |
-| 明确上游错误且未发出 / 空结果 | 零费用 |
+| 客户端取消 / Gateway 超时（合成 504，已发出） | **零费用**（与上游 4xx/5xx 对齐；入口预检只拦额度，不落成实扣） |
+| 明确上游错误 / 网络 502 / 空结果 | 零费用 |
 | 无 mode 且无正 `image_*` | **不计费** |
 
 ### per_image 模式
@@ -179,7 +179,7 @@ charged ≈
 | 规则 | 行为 |
 |------|------|
 | 成功出图 | 按有效返回图片数 + 请求参考图数结算；**忽略** usage tokens |
-| 客户端取消 / Gateway 超时 / 结果不明（已发出） | 默认按请求张数扣费（`uncertain_result_policy=requested`）；可配置 `zero` |
+| 客户端取消 / Gateway 超时 / 结果不明（已发出） | **零费用**（与 token / 上游 4xx/5xx 对齐；`uncertain_result_policy` 不再作为 abort 扣费开关） |
 | 明确失败且未发出 / 空结果 | 零费用 |
 | 无显式 `image_billing_mode: per_image` 的 legacy `image` 块 | **不计费**（避免旧数据突然扣款） |
 

--- a/packages/proxy/src/services/image-usage-charge.test.ts
+++ b/packages/proxy/src/services/image-usage-charge.test.ts
@@ -1,9 +1,11 @@
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
 import type { GatewayRepositories } from '@octafuse/core';
+import { parsePricingProfile, resolveImageBillingMode } from '@octafuse/core';
 import {
 	estimateImageBudgetPrecheck,
 	estimateImageCosts,
+	shouldChargeUncertainImageResult,
 	withClientAbortPrecheckAudit,
 	withUncertainResultAudit,
 } from './image-usage-charge';
@@ -302,5 +304,92 @@ describe('uncertain result precheck audit', () => {
 		const audited = withUncertainResultAudit(precheck, 'gateway_timeout_precheck');
 		assert.equal(audited.chargedCost, precheck.chargedCost);
 		assert.ok(audited.pricingAuditJson.includes('gateway_timeout_precheck'));
+	});
+});
+
+describe('shouldChargeUncertainImageResult', () => {
+	const tokenProfile = parsePricingProfile(TOKEN_PROFILE);
+	const perImageRequested = parsePricingProfile(PER_IMAGE_PROFILE);
+	const perImageZero = parsePricingProfile(
+		JSON.stringify({
+			image_billing_mode: 'per_image',
+			image: { default: 0.04, uncertain_result_policy: 'zero' },
+		})
+	);
+	const tokenPrecheck = { chargedCost: 0.98 };
+
+	it('does not charge token-mode client abort even when precheck > 0', () => {
+		assert.equal(
+			shouldChargeUncertainImageResult({
+				status: 'error',
+				mode: resolveImageBillingMode(tokenProfile),
+				profile: tokenProfile,
+				imageAbortReason: 'client_abort',
+				clientAbortPrecheck: tokenPrecheck,
+			}),
+			false
+		);
+	});
+
+	it('does not charge token-mode gateway timeout even when precheck > 0', () => {
+		assert.equal(
+			shouldChargeUncertainImageResult({
+				status: 'error',
+				mode: resolveImageBillingMode(tokenProfile),
+				profile: tokenProfile,
+				imageAbortReason: 'gateway_timeout',
+				clientAbortPrecheck: tokenPrecheck,
+			}),
+			false
+		);
+	});
+
+	it('does not charge explicit upstream 5xx / network 502 (error without abort)', () => {
+		assert.equal(
+			shouldChargeUncertainImageResult({
+				status: 'error',
+				mode: resolveImageBillingMode(tokenProfile),
+				profile: tokenProfile,
+				imageAbortReason: null,
+				clientAbortPrecheck: null,
+			}),
+			false
+		);
+		assert.equal(
+			shouldChargeUncertainImageResult({
+				status: 'error',
+				mode: resolveImageBillingMode(perImageRequested),
+				profile: perImageRequested,
+				imageAbortReason: null,
+				clientAbortPrecheck: null,
+			}),
+			false
+		);
+	});
+
+	it('does not charge per_image abort even when uncertain_result_policy is requested', () => {
+		assert.equal(
+			shouldChargeUncertainImageResult({
+				status: 'error',
+				mode: resolveImageBillingMode(perImageRequested),
+				profile: perImageRequested,
+				imageAbortReason: 'client_abort',
+				clientAbortPrecheck: { chargedCost: 0.04 },
+			}),
+			false
+		);
+	});
+
+	it('does not charge per_image abort when uncertain_result_policy is zero', () => {
+		assert.equal(
+			shouldChargeUncertainImageResult({
+				status: 'error',
+				mode: resolveImageBillingMode(perImageZero),
+				profile: perImageZero,
+				imageAbortReason: 'gateway_timeout',
+				clientAbortPrecheck: { chargedCost: 0.04 },
+			}),
+			false
+		);
 	});
 });

--- a/packages/proxy/src/services/image-usage-charge.ts
+++ b/packages/proxy/src/services/image-usage-charge.ts
@@ -78,7 +78,29 @@ export type ImageCostBreakdown = {
 export type UncertainResultUsageSource =
 	| 'client_abort_precheck'
 	| 'gateway_timeout_precheck'
+	| 'client_abort_no_charge'
+	| 'gateway_timeout_no_charge'
 	| 'uncertain_requested';
+
+export type ImageAbortReason = 'client_abort' | 'gateway_timeout';
+
+export type ShouldChargeUncertainImageResultParams = {
+	status: 'success' | 'error';
+	mode: ReturnType<typeof resolveImageBillingMode>;
+	profile: ParsedPricingProfile | null;
+	imageAbortReason?: ImageAbortReason | null;
+	clientAbortPrecheck?: { chargedCost: number } | null;
+};
+
+/**
+ * 未确认结果（客户端取消 / Gateway 超时）是否向用户扣费。
+ * token / per_image 一律不扣（与上游 4xx/5xx 对齐）；`uncertain_result_policy` 不再作为 abort 扣费开关。
+ */
+export function shouldChargeUncertainImageResult(
+	_params: ShouldChargeUncertainImageResultParams
+): boolean {
+	return false;
+}
 
 function pricingAtUtcFromParams(requestStartedAtMs?: number): Date {
 	const requestedPricingAtUtc =
@@ -416,13 +438,15 @@ export function withClientAbortPrecheckAudit(costs: ImageCostBreakdown): ImageCo
 }
 
 function resolveUncertainUsageSource(
-	imageAbortReason?: 'client_abort' | 'gateway_timeout' | null
+	imageAbortReason?: ImageAbortReason | null,
+	options?: { charged?: boolean }
 ): UncertainResultUsageSource {
+	const charged = options?.charged ?? true;
 	if (imageAbortReason === 'client_abort') {
-		return 'client_abort_precheck';
+		return charged ? 'client_abort_precheck' : 'client_abort_no_charge';
 	}
 	if (imageAbortReason === 'gateway_timeout') {
-		return 'gateway_timeout_precheck';
+		return charged ? 'gateway_timeout_precheck' : 'gateway_timeout_no_charge';
 	}
 	return 'uncertain_requested';
 }
@@ -463,11 +487,10 @@ export type RecordImageUsageParams = {
 	/** 上游解析的 token usage；token 路径扣费权威 */
 	imageUsage?: ImageTokenUsage | null;
 	/**
-	 * 客户端取消 / Gateway 超时：传入入口预算预检 breakdown（token 路径扣费权威）。
-	 * per_image 路径仍按 profile uncertain_result_policy 重算张数。
+	 * 客户端取消 / Gateway 超时：传入入口预算预检 breakdown，仅作审计对照，不再作为扣费权威。
 	 */
 	clientAbortPrecheck?: ImageCostBreakdown | null;
-	imageAbortReason?: 'client_abort' | 'gateway_timeout' | null;
+	imageAbortReason?: ImageAbortReason | null;
 	resultConfirmed?: boolean;
 	upstreamSupplierCostUsdTicks?: number | null;
 	providerKeyId?: string | null;
@@ -480,7 +503,7 @@ export type RecordImageUsageParams = {
 };
 
 /**
- * 写入用量日志并在成功（或防亏损预检扣费）且 charged>0 时扣费。
+ * 写入用量日志并在成功且 charged>0 时扣费。取消 / 超时 / 明确错误一律不扣。
  */
 export async function recordImageUsage(params: RecordImageUsageParams): Promise<{
 	requestLogId: string;
@@ -495,13 +518,13 @@ export async function recordImageUsage(params: RecordImageUsageParams): Promise<
 			imageAbortReason === 'gateway_timeout' ||
 			params.clientAbortPrecheck != null);
 
-	const chargeUncertain =
-		isUncertainCharge &&
-		((params.clientAbortPrecheck != null && params.clientAbortPrecheck.chargedCost > 0) ||
-			(mode === 'per_image' &&
-				profile != null &&
-				profileHasImagePerImagePricing(profile) &&
-				(profile.image?.uncertain_result_policy ?? 'requested') !== 'zero'));
+	const chargeUncertain = shouldChargeUncertainImageResult({
+		status: params.status,
+		mode,
+		profile,
+		imageAbortReason,
+		clientAbortPrecheck: params.clientAbortPrecheck,
+	});
 
 	const outputImageCountForLog =
 		params.status === 'success'
@@ -512,53 +535,20 @@ export async function recordImageUsage(params: RecordImageUsageParams): Promise<
 
 	let costs: ImageCostBreakdown;
 	if (isUncertainCharge) {
-		if (mode === 'per_image' && profile && profileHasImagePerImagePricing(profile)) {
-			const policy = profile.image?.uncertain_result_policy ?? 'requested';
-			if (policy === 'zero') {
-				const factors = await resolveRouteFactors(
-					params.repos,
-					params.billing.routePriceOverrideJson,
-					params.billing.requestStartedAtMs
-				);
-				costs = zeroImageCostBreakdown(params.billing, factors, 'image_per_image', {
-					uncertain_result_policy: 'zero',
-					result_confirmed: false,
-					usage_source: resolveUncertainUsageSource(imageAbortReason),
-				});
-			} else {
-				const factors = await resolveRouteFactors(
-					params.repos,
-					params.billing.routePriceOverrideJson,
-					params.billing.requestStartedAtMs
-				);
-				costs = estimateImagePerImageCosts(params.billing, profile, factors, {
-					outputCount: params.billing.imageCount,
-					referenceCount: params.billing.referenceCount,
-					auditExtra: {
-						result_confirmed: false,
-						uncertain_result_policy: policy,
-					},
-				});
-				costs = withUncertainResultAudit(
-					costs,
-					resolveUncertainUsageSource(imageAbortReason)
-				);
-			}
-		} else if (params.clientAbortPrecheck && params.clientAbortPrecheck.chargedCost > 0) {
-			costs = withUncertainResultAudit(
-				params.clientAbortPrecheck,
-				resolveUncertainUsageSource(imageAbortReason)
-			);
-		} else {
-			const factors = await resolveRouteFactors(
-				params.repos,
-				params.billing.routePriceOverrideJson,
-				params.billing.requestStartedAtMs
-			);
-			costs = zeroImageCostBreakdown(params.billing, factors, 'image_tokens', {
-				error: 'request_failed',
-			});
-		}
+		const factors = await resolveRouteFactors(
+			params.repos,
+			params.billing.routePriceOverrideJson,
+			params.billing.requestStartedAtMs
+		);
+		const billingKind =
+			mode === 'per_image' && profile && profileHasImagePerImagePricing(profile)
+				? 'image_per_image'
+				: 'image_tokens';
+		costs = zeroImageCostBreakdown(params.billing, factors, billingKind, {
+			error: 'request_failed',
+			result_confirmed: false,
+			usage_source: resolveUncertainUsageSource(imageAbortReason, { charged: false }),
+		});
 	} else if (params.status === 'error') {
 		const factors = await resolveRouteFactors(
 			params.repos,
@@ -650,13 +640,15 @@ export async function recordImageUsage(params: RecordImageUsageParams): Promise<
 					input_image_count: logInputImages,
 					output_image_count: logOutputImages,
 				})
-			: chargeUncertain
+			: isUncertainCharge
 				? JSON.stringify({
 						image_count: logOutputImages,
 						billing_kind: costs.billingKind,
 						input_image_count: logInputImages,
 						output_image_count: logOutputImages,
-						usage_source: resolveUncertainUsageSource(imageAbortReason),
+						usage_source: resolveUncertainUsageSource(imageAbortReason, {
+							charged: chargeUncertain,
+						}),
 					})
 				: null);
 


### PR DESCRIPTION
- Clarified billing rules for token and per_image modes, ensuring zero charges for client aborts and gateway timeouts.
- Revised documentation to reflect changes in precheck logic and billing behavior for uncertain results.
- Enhanced the `shouldChargeUncertainImageResult` function to align with updated billing policies, ensuring consistent handling of abort scenarios.
- Updated tests to validate the new billing logic and ensure accurate charge assessments for various image usage scenarios.

These changes aim to improve the clarity and accuracy of image billing processes and enhance the overall user experience.

## Summary

<!-- What does this PR change and why? -->

## Target branch

<!-- Normal features/contributions target develop. Releases use release/X.Y.Z when a freeze branch is needed; current-release hotfixes use hotfix/X.Y.Z and target main. -->

- [ ] This PR targets `develop`, or a maintainer has confirmed `main` / another base branch for a release or hotfix.

## Type of change

<!-- Check all that apply -->

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change (describe migration / release notes impact)
- [ ] Documentation only
- [ ] Build / CI / chore

## Checklist

- [ ] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) (including the contribution license terms).
- [ ] For user-visible behavior or API changes, I updated docs where appropriate.
- [ ] I added a changeset for user-visible changes, or documented why it is deferred / unnecessary.
- [ ] I ran relevant tests or smoke scripts locally when applicable (e.g. `npm run test:gateway:postgres-smoke`).

## Related issues

<!-- Link e.g. Fixes #123 -->
