### PR TITLE
feat(admin): add GLM-5.3-Flash model preset

### DIFF
--- a/packages/admin/lib/model-presets/zhipu.json
+++ b/packages/admin/lib/model-presets/zhipu.json
@@ -224,5 +224,53 @@
 			]
 		},
 		"released": "2026-08-14"
+	},
+	{
+		"id": "glm-5.3-flash",
+		"display_name": "GLM-5.3-Flash",
+		"description": "A native multimodal GLM Flash model for visual coding, agents, and professional workflows. It outperforms GLM-5.2 at a fraction of the cost, with native image, video, and file understanding.",
+		"i18n": {
+			"en": "A native multimodal GLM Flash model for visual coding, agents, and professional workflows. It outperforms GLM-5.2 at a fraction of the cost, with native image, video, and file understanding.",
+			"zh": "面向视觉编程、Agent 与专业工作流的 GLM 原生多模态 Flash 模型。以远低于 GLM-5.2 的成本提供更强智能，原生支持图片、视频与文件理解。"
+		},
+		"vendor": "zhipu",
+		"context_window": 1000000,
+		"max_tokens": 128000,
+		"pricing": {
+			"usd": {
+				"tiers": [
+					{
+						"upto": null,
+						"input_price": 0.15,
+						"output_price": 0.5,
+						"cache_read_price": 0.03,
+						"cache_write_price": null
+					}
+				]
+			},
+			"cny": {
+				"tiers": [
+					{
+						"upto": null,
+						"input_price": 0.8,
+						"output_price": 2.8,
+						"cache_read_price": 0.23,
+						"cache_write_price": null
+					}
+				]
+			}
+		},
+		"modalities": {
+			"input": [
+				"text",
+				"image",
+				"video",
+				"file"
+			],
+			"output": [
+				"text"
+			]
+		},
+		"released": "2026-08-26"
 	}
 ]

--- a/packages/admin/lib/services/admin/import-catalog-billing.test.ts
+++ b/packages/admin/lib/services/admin/import-catalog-billing.test.ts
@@ -30,6 +30,18 @@ describe('import catalog pricing preview follows billing currency', () => {
 		assert.equal(usd!.pricing_label, '$1.4 / $4.4 /M');
 		assert.equal(cny!.pricing_label, '¥8 / ¥28 /M');
 	});
+
+	it('includes glm-5.3-flash with official Z.AI and BigModel list prices', () => {
+		const usd = listStaticModelPresetCatalogForAdmin('USD').find((r) => r.id === 'glm-5.3-flash');
+		const cny = listStaticModelPresetCatalogForAdmin('CNY').find((r) => r.id === 'glm-5.3-flash');
+		assert.ok(usd);
+		assert.ok(cny);
+		assert.equal(usd!.display_name, 'GLM-5.3-Flash');
+		assert.equal(usd!.context_window, 1000000);
+		assert.equal(usd!.max_tokens, 128000);
+		assert.equal(usd!.pricing_label, '$0.15 / $0.5 /M');
+		assert.equal(cny!.pricing_label, '¥0.8 / ¥2.8 /M');
+	});
 });
 
 describe('import catalog localized model metadata', () => {


### PR DESCRIPTION
Add glm-5.3-flash to the Zhipu model presets using official Z.AI/BigModel specs and list prices (not discounted rates). The model supports a 1M context window, 128K max output tokens, and native multimodal input (text, image, video, file).

Include USD and CNY tiered pricing with cache-read rates, add a test verifying the preset appears correctly in the admin catalog pricing preview, and add a patch changeset.

## Summary

<!-- What does this PR change and why? -->

## Target branch

<!-- Normal features/contributions target develop. Releases use release/X.Y.Z when a freeze branch is needed; current-release hotfixes use hotfix/X.Y.Z and target main. -->

- [ ] This PR targets `develop`, or a maintainer has confirmed `main` / another base branch for a release or hotfix.

## Type of change

<!-- Check all that apply -->

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change (describe migration / release notes impact)
- [ ] Documentation only
- [ ] Build / CI / chore

## Checklist

- [ ] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) (including the contribution license terms).
- [ ] For user-visible behavior or API changes, I updated docs where appropriate.
- [ ] I added a changeset for user-visible changes, or documented why it is deferred / unnecessary.
- [ ] I ran relevant tests or smoke scripts locally when applicable (e.g. `npm run test:gateway:postgres-smoke`).

## Related issues

<!-- Link e.g. Fixes #123 -->
