### PR TITLE
feat(admin): add Qwen3.8 Flash model preset

### DIFF
--- a/packages/admin/lib/model-presets/aliyun.json
+++ b/packages/admin/lib/model-presets/aliyun.json
@@ -94,6 +94,53 @@
 		"released": "2026-07-19"
 	},
 	{
+		"id": "qwen3.8-flash",
+		"display_name": "Qwen3.8 Flash",
+		"description": "A fast multimodal Qwen3.8 model with a native 1M context window for coding, agents, documents, and visual understanding. Near-flagship quality at a fraction of Qwen3.8 Max cost, with image and video input.",
+		"i18n": {
+			"en": "A fast multimodal Qwen3.8 model with a native 1M context window for coding, agents, documents, and visual understanding. Near-flagship quality at a fraction of Qwen3.8 Max cost, with image and video input.",
+			"zh": "通义千问最新多模态 Flash 模型，兼具理解生成能力与响应速度。原生百万级上下文，适合编程辅助、智能体协作、超长文档与图文/长视频理解，以更低推理成本接近旗舰效果。"
+		},
+		"vendor": "aliyun",
+		"context_window": 1000000,
+		"max_tokens": 128000,
+		"pricing": {
+			"usd": {
+				"tiers": [
+					{
+						"upto": null,
+						"input_price": 0.16,
+						"output_price": 0.47,
+						"cache_read_price": 0.016,
+						"cache_write_price": 0.2
+					}
+				]
+			},
+			"cny": {
+				"tiers": [
+					{
+						"upto": null,
+						"input_price": 1,
+						"output_price": 3,
+						"cache_read_price": 0.1,
+						"cache_write_price": 1.25
+					}
+				]
+			}
+		},
+		"modalities": {
+			"input": [
+				"text",
+				"image",
+				"video"
+			],
+			"output": [
+				"text"
+			]
+		},
+		"released": "2026-08-26"
+	},
+	{
 		"id": "qwen3.7-plus",
 		"display_name": "Qwen3.7 Plus",
 		"description": "A cost-efficient multimodal Qwen model for general reasoning, vision, and production applications. It combines text and image understanding with a cost-conscious design for production-scale multimodal reasoning.",

--- a/packages/admin/lib/services/admin/import-catalog-billing.test.ts
+++ b/packages/admin/lib/services/admin/import-catalog-billing.test.ts
@@ -42,6 +42,18 @@ describe('import catalog pricing preview follows billing currency', () => {
 		assert.equal(usd!.pricing_label, '$0.15 / $0.5 /M');
 		assert.equal(cny!.pricing_label, '¥0.8 / ¥2.8 /M');
 	});
+
+	it('includes qwen3.8-flash with official Model Studio list prices', () => {
+		const usd = listStaticModelPresetCatalogForAdmin('USD').find((r) => r.id === 'qwen3.8-flash');
+		const cny = listStaticModelPresetCatalogForAdmin('CNY').find((r) => r.id === 'qwen3.8-flash');
+		assert.ok(usd);
+		assert.ok(cny);
+		assert.equal(usd!.display_name, 'Qwen3.8 Flash');
+		assert.equal(usd!.context_window, 1000000);
+		assert.equal(usd!.max_tokens, 128000);
+		assert.equal(usd!.pricing_label, '$0.16 / $0.47 /M');
+		assert.equal(cny!.pricing_label, '¥1 / ¥3 /M');
+	});
 });
 
 describe('import catalog localized model metadata', () => {


### PR DESCRIPTION
Introduce the Qwen3.8 Flash model to the Aliyun model presets, featuring a 1M context window, 128K max output tokens, and support for multimodal input (text, image, video). Include USD and CNY tiered pricing details, and add a test to verify the model's presence and pricing in the admin catalog.

## Summary

<!-- What does this PR change and why? -->

## Target branch

<!-- Normal features/contributions target develop. Releases use release/X.Y.Z when a freeze branch is needed; current-release hotfixes use hotfix/X.Y.Z and target main. -->

- [ ] This PR targets `develop`, or a maintainer has confirmed `main` / another base branch for a release or hotfix.

## Type of change

<!-- Check all that apply -->

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change (describe migration / release notes impact)
- [ ] Documentation only
- [ ] Build / CI / chore

## Checklist

- [ ] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) (including the contribution license terms).
- [ ] For user-visible behavior or API changes, I updated docs where appropriate.
- [ ] I added a changeset for user-visible changes, or documented why it is deferred / unnecessary.
- [ ] I ran relevant tests or smoke scripts locally when applicable (e.g. `npm run test:gateway:postgres-smoke`).

## Related issues

<!-- Link e.g. Fixes #123 -->
