### PR TITLE
Release 2.8.0: merge develop into main

### DIFF
--- a/.changeset/release-2-8-0.md
+++ b/.changeset/release-2-8-0.md
@@ -1,0 +1,38 @@
+---
+"octafuse": minor
+---
+
+OctaFuse Gateway v2.8.0 把周期额度与永久额度拆开记账，打通阿里云百炼千问 / 万相走 OpenAI Images 入口的转换路径，并让 Docker 管理后台支持实时语音 WebSocket。
+
+### Proxy
+
+- **永久额度扣费**：先扣周期额度，不够的差额扣永久额度；`budget_max` 非空时总剩余 = 周期剩余 + wallet 余额，总剩余 ≤ 0 才 403。周期上限为 0 但 wallet 仍有余额时可继续请求。请求日志增加 `charged_wallet_cost`。
+- **DashScope 生图转换**：客户端仍打 `POST /v1/images/generations`；适配器 `dashscope-image-qwen` / `dashscope-image-wan` 改写为 DashScope `images.generations.multimodal`。千问 / 万相按张计费；千问 Pro 从响应 usage 反推 1K/2K 档。默认返回 URL，`response_format=b64_json` 时下载 OSS 再转 base64。
+- **额度预检**：Images / Audio / Tools 预检与实扣使用同一套周期 + 永久总余额，不再把 `budget_max=0` 误判为超额。
+
+### Admin
+
+- **永久额度加额**：新增 `POST /api/admin/users/:id/wallet/credit`（`kind` + `external_ref` 幂等）。用户详情拆开展示周期额度与永久额度；加购不要再写入 `budget_max`。`PATCH` 仍可修正 wallet 绝对值。
+- **DashScope 生图联调**：Playground / Simulator 对千问 / 万相转换路由使用 OpenAI Images JSON；调试台改写成 multimodal，模拟器走 Proxy `/v1/images/generations`。
+- **路由适配器**：下拉项标明 `request → upstream` 映射，避免透传与转换混淆。
+- **实时语音**：DashScope realtime ASR 默认改用浏览器麦克风；Docker Admin 运行层带上 `ws`，Node 入口为 `node-server.mjs`，调试台实时 ASR 不再 501。
+- **模型预设**：新增 `hy4-preview`、`qwen3.8-flash`、`glm-5.3-flash`。目录导入不再写入 `model_tags`，标签由运营导入后自行维护。
+- **模型 / 路由编辑**：模型弹窗可预览 pricing profile JSON；路由时段与倍率表格展示整理。
+
+### Core
+
+- **迁移 0027**：`users` 增加 `wallet_granted` / `wallet_spent`；`user_audit_logs.dedup_key` 唯一约束；`api_key_request_logs.charged_wallet_cost`。回填把 `budget_max − max(spent, base)` 的剩余迁入 wallet；`budget_max IS NULL` 与到期清零行（`max=0 AND period=none`）不抬回 `budget_base`；超支欠账钳到 0。
+
+### 文档
+
+- **永久额度**：用户接口、Admin API、数据模型与请求生命周期写明先周期后永久、加额幂等与 0027 回填。
+- **DashScope 生图**：新增架构文档，标明 OpenAI Images 入口、转换适配器、按张计费与验收路径。
+- **Docker Admin**：standalone 入口、`ws` 拷贝与实时 WebSocket 约束写入部署与构建说明。
+
+### 升级说明
+
+- **数据库迁移**：必须应用 **0027**；三种数据库语义一致。上线前可用 `docs/operators/migrations/0027-user-wallet-credit-audit.sql` 只读核对。
+- **发布顺序**：先部署同版本 proxy / admin 代码（新列默认 0）；再执行 migrate Job；门户再切到 `POST /api/admin/users/:id/wallet/credit`。不要把加购继续加进 `budget_max`。
+- **配置变更**：阿里云千问 / 万相生图需路由适配器选 `dashscope-image-qwen` 或 `dashscope-image-wan`，请求协议保持 `openai` / `images.generations`。Token Plan 须显式覆盖 `images.generations.multimodal`。
+- **兼容性影响**：Chat / Messages / Gemini / Audio / Responses 入口不变。额度判定改为总余额；周期用尽但 wallet 有余额的用户将从 403 变为可继续调用。已导入模型行不会被静态目录覆盖。
+- **建议操作**：部署后核验 0027 回填、wallet 加额幂等与请求日志 `charged_wallet_cost`；用 Playground / Simulator 冒烟 DashScope 生图、实时 ASR（麦克风）与既有 chat / messages / gemini / images / audio；如需新模型目录再导入对应预设。

--- a/docs/releases/2.8.0.md
+++ b/docs/releases/2.8.0.md
@@ -1,0 +1,38 @@
+## 本次更新
+
+OctaFuse Gateway v2.8.0 把周期额度与永久额度拆开记账，打通阿里云百炼千问 / 万相走 OpenAI Images 入口的转换路径，并让 Docker 管理后台支持实时语音 WebSocket。
+
+## 变更内容
+
+### Proxy
+
+- **永久额度扣费**：先扣周期额度，不够的差额扣永久额度；`budget_max` 非空时总剩余 = 周期剩余 + wallet 余额，总剩余 ≤ 0 才 403。周期上限为 0 但 wallet 仍有余额时可继续请求。请求日志增加 `charged_wallet_cost`。
+- **DashScope 生图转换**：客户端仍打 `POST /v1/images/generations`；适配器 `dashscope-image-qwen` / `dashscope-image-wan` 改写为 DashScope `images.generations.multimodal`。千问 / 万相按张计费；千问 Pro 从响应 usage 反推 1K/2K 档。默认返回 URL，`response_format=b64_json` 时下载 OSS 再转 base64。
+- **额度预检**：Images / Audio / Tools 预检与实扣使用同一套周期 + 永久总余额，不再把 `budget_max=0` 误判为超额。
+
+### Admin
+
+- **永久额度加额**：新增 `POST /api/admin/users/:id/wallet/credit`（`kind` + `external_ref` 幂等）。用户详情拆开展示周期额度与永久额度；加购不要再写入 `budget_max`。`PATCH` 仍可修正 wallet 绝对值。
+- **DashScope 生图联调**：Playground / Simulator 对千问 / 万相转换路由使用 OpenAI Images JSON；调试台改写成 multimodal，模拟器走 Proxy `/v1/images/generations`。
+- **路由适配器**：下拉项标明 `request → upstream` 映射，避免透传与转换混淆。
+- **实时语音**：DashScope realtime ASR 默认改用浏览器麦克风；Docker Admin 运行层带上 `ws`，Node 入口为 `node-server.mjs`，调试台实时 ASR 不再 501。
+- **模型预设**：新增 `hy4-preview`、`qwen3.8-flash`、`glm-5.3-flash`。目录导入不再写入 `model_tags`，标签由运营导入后自行维护。
+- **模型 / 路由编辑**：模型弹窗可预览 pricing profile JSON；路由时段与倍率表格展示整理。
+
+### Core
+
+- **迁移 0027**：`users` 增加 `wallet_granted` / `wallet_spent`；`user_audit_logs.dedup_key` 唯一约束；`api_key_request_logs.charged_wallet_cost`。回填把 `budget_max − max(spent, base)` 的剩余迁入 wallet；`budget_max IS NULL` 与到期清零行（`max=0 AND period=none`）不抬回 `budget_base`；超支欠账钳到 0。
+
+### 文档
+
+- **永久额度**：用户接口、Admin API、数据模型与请求生命周期写明先周期后永久、加额幂等与 0027 回填。
+- **DashScope 生图**：新增架构文档，标明 OpenAI Images 入口、转换适配器、按张计费与验收路径。
+- **Docker Admin**：standalone 入口、`ws` 拷贝与实时 WebSocket 约束写入部署与构建说明。
+
+## 升级说明
+
+- 数据库迁移：必须应用 **0027**；三种数据库语义一致。上线前可用 `docs/operators/migrations/0027-user-wallet-credit-audit.sql` 只读核对。
+- 发布顺序：先部署同版本 proxy / admin 代码（新列默认 0）；再执行 migrate Job；门户再切到 `POST /api/admin/users/:id/wallet/credit`。不要把加购继续加进 `budget_max`。
+- 配置变更：阿里云千问 / 万相生图需路由适配器选 `dashscope-image-qwen` 或 `dashscope-image-wan`，请求协议保持 `openai` / `images.generations`。Token Plan 须显式覆盖 `images.generations.multimodal`。
+- 兼容性影响：Chat / Messages / Gemini / Audio / Responses 入口不变。额度判定改为总余额；周期用尽但 wallet 有余额的用户将从 403 变为可继续调用。已导入模型行不会被静态目录覆盖。
+- 建议操作：部署后核验 0027 回填、wallet 加额幂等与请求日志 `charged_wallet_cost`；用 Playground / Simulator 冒烟 DashScope 生图、实时 ASR（麦克风）与既有 chat / messages / gemini / images / audio；如需新模型目录再导入对应预设。


### PR DESCRIPTION
## Summary

- 将 `develop` 合入 `main`，携带 v2.8.0 的 minor changeset（周期 / 永久额度拆分、DashScope 千问 / 万相生图转换、Docker Admin 实时 WebSocket）。
- 合入后由 Release workflow 打开 **chore: version packages** PR；本 PR 不含版本号 bump / CHANGELOG 消费，那些由下一步 Version Packages PR 完成。
- 功能已在 #126–#136 合入 `main`，此前缺少 changeset，因此 Release 没有打开 Version PR。本次只补发布记录。

## Target branch

- [x] This PR targets `main` for a formal release.

## Type of change

- [x] New feature
- [x] Breaking change (describe migration / release notes impact)
- [x] Build / CI / chore

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) (including the contribution license terms).
- [x] For user-visible behavior or API changes, I updated docs where appropriate.
- [x] I added a changeset for user-visible changes, or documented why it is deferred / unnecessary.
- [ ] I ran relevant tests or smoke scripts locally when applicable (e.g. `npm run test:gateway:postgres-smoke`).

## Test plan

- [ ] 确认 PR 仅包含 `.changeset/release-2-8-0.md` 与 `docs/releases/2.8.0.md`
- [ ] 合并后确认 Release workflow 新建 Version Packages PR，版本为 **2.8.0**
- [ ] 审核 Version PR 的 `CHANGELOG.md` 与四个 `package.json` 版本后再合并
- [ ] 确认打出 `v2.8.0` tag，且 Octafuse Docker Images 构建 proxy / admin / migrate
- [ ] 发版完成后将 `main` 同步回 `develop`


Made with [Cursor](https://cursor.com)