### PR TITLE
feat: add Flatkey provider integration and enhance catalog links

### DIFF
--- a/docs/developers/reference/provider-import-presets.md
+++ b/docs/developers/reference/provider-import-presets.md
@@ -26,7 +26,8 @@ Admin 在 **Providers** 页面提供「从模板导入」：预填各协议的 B
 1. **新增模板**：在 `provider-import-presets.json` 追加对象；保持 `name` 可读且尽量不与常见手工命名撞车（导入时会自动去重后缀）。
 2. **核对 endpoint**：以各云厂商**当前官方文档**为准；OpenAI 可分别配置 `chat`、`responses`、Images、Audio 等能力端点，DashScope 使用独立协议配置；Gemini Vertex 兼容聚合商写完整 `{model}` 前缀并设 `gemini.auth: "bearer"`（如七牛、ZenMux）；正式 Vertex 用项目级占位 URL（`YOUR_PROJECT_ID`），OpenAI 只配 Chat Completions（`.../endpoints/openapi/chat/completions`），原生 Gemini 配 `auth: "bearer"`，密钥栏贴 **GCP 服务账号 JSON**（不是 Vertex API Key）；`description` 中可提示「以控制台为准」。
 3. **占位密钥**：勿改为真实密钥写入仓库；占位串为 `PROVIDER_IMPORT_PENDING_API_KEY`（见 `provider-import-preset.ts`）。
-4. **扩展**：按同样 JSON 结构追加供应商模板即可；**勿**在 JSON 中写 provider id（与 catalog 键无关）。
+4. **Catalog 链接**：`catalog.links.platform` 为官网；`api_keys` 为密钥管理页（可省略）；`referral` 仅在有可确认的邀请/注册 URL 时填写，**不要**用邀请链接覆盖 `platform`。Admin 与 Website 的「点击前往」出站顺序为 `referral` → `api_keys` → `platform`。链接只存在静态预设中，导入后按模板名或 endpoint 签名叠加，不写入 `providers` 表。
+5. **扩展**：按同样 JSON 结构追加供应商模板即可；**勿**在 JSON 中写 provider id（与 catalog 键无关）。
 
 ## 与模型导入的关系
 

--- a/packages/admin/app/gateway/providers/components/provider-card.tsx
+++ b/packages/admin/app/gateway/providers/components/provider-card.tsx
@@ -9,6 +9,7 @@ import { useTranslations } from 'next-intl';
 import { VendorIcon } from '@/components/model-vendor-icon';
 import type { GatewayProvider, ProviderKeyStatusKind } from '../types';
 import { getProviderKeyStatus, getProviderProtocolSummaries } from '../provider-utils';
+import { ProviderCatalogOutboundLink } from './provider-catalog-outbound-link';
 import { ProviderProtocolIcon } from './provider-protocol-icon';
 
 type ProviderCardProps = {
@@ -160,15 +161,24 @@ export function ProviderCard(props: ProviderCardProps) {
 			</div>
 
 			<div className="pointer-events-none relative z-10 flex items-center justify-between gap-2">
-				<span
-					className={`inline-flex min-w-0 items-center gap-1.5 rounded-md px-1.5 py-0.5 text-[11px] font-medium ring-1 ring-inset ${STATUS_BADGE[keyStatus]}`}
-				>
+				<div className="flex min-w-0 items-center gap-2">
 					<span
-						className={`h-1.5 w-1.5 shrink-0 rounded-full ${STATUS_DOT[keyStatus]}`}
-						aria-hidden
-					/>
-					<span className="truncate">{statusLabel}</span>
-				</span>
+						className={`inline-flex min-w-0 items-center gap-1.5 rounded-md px-1.5 py-0.5 text-[11px] font-medium ring-1 ring-inset ${STATUS_BADGE[keyStatus]}`}
+					>
+						<span
+							className={`h-1.5 w-1.5 shrink-0 rounded-full ${STATUS_DOT[keyStatus]}`}
+							aria-hidden
+						/>
+						<span className="truncate">{statusLabel}</span>
+					</span>
+					{(keyStatus === 'no_key' || keyStatus === 'pending') && (
+						<ProviderCatalogOutboundLink
+							links={provider.catalog_links}
+							stopPropagation
+							className="pointer-events-auto inline-flex min-w-0 items-center gap-1 text-[11px] font-medium text-blue-700 hover:text-blue-800"
+						/>
+					)}
+				</div>
 				<button
 					type="button"
 					onClick={(event) => {

--- a/packages/admin/app/gateway/providers/components/provider-catalog-outbound-link.tsx
+++ b/packages/admin/app/gateway/providers/components/provider-catalog-outbound-link.tsx
@@ -1,0 +1,49 @@
+'use client';
+
+import { ArrowTopRightOnSquareIcon } from '@heroicons/react/24/outline';
+import { useTranslations } from 'next-intl';
+import {
+	providerCatalogOutboundRel,
+	resolveProviderCatalogOutbound,
+	type ProviderCatalogLinks,
+} from '@/lib/provider-import-preset';
+
+type ProviderCatalogOutboundLinkProps = {
+	links: ProviderCatalogLinks | null | undefined;
+	className?: string;
+	/** When the parent card swallows clicks, keep this link above it. */
+	stopPropagation?: boolean;
+};
+
+export function ProviderCatalogOutboundLink(props: ProviderCatalogOutboundLinkProps) {
+	const { links, className, stopPropagation } = props;
+	const t = useTranslations('providers.outbound');
+	const outbound = resolveProviderCatalogOutbound(links);
+	if (!outbound) return null;
+
+	return (
+		<a
+			href={outbound.href}
+			target="_blank"
+			rel={providerCatalogOutboundRel(outbound.kind)}
+			className={className}
+			onClick={
+				stopPropagation
+					? (event) => {
+							event.stopPropagation();
+						}
+					: undefined
+			}
+			onKeyDown={
+				stopPropagation
+					? (event) => {
+							event.stopPropagation();
+						}
+					: undefined
+			}
+		>
+			{t('go')}
+			<ArrowTopRightOnSquareIcon className="h-3.5 w-3.5 shrink-0" aria-hidden />
+		</a>
+	);
+}

--- a/packages/admin/app/gateway/providers/components/provider-import-modal.tsx
+++ b/packages/admin/app/gateway/providers/components/provider-import-modal.tsx
@@ -6,6 +6,7 @@ import { VendorIcon } from '@/components/model-vendor-icon';
 import { summarizeOpenAiImportEndpoints } from '@/lib/provider-import-preset';
 import { useTranslations } from 'next-intl';
 import type { ProviderImportCatalogRow } from '../types';
+import { ProviderCatalogOutboundLink } from './provider-catalog-outbound-link';
 
 type ProviderImportModalProps = {
 	open: boolean;
@@ -197,7 +198,14 @@ export function ProviderImportModal(props: ProviderImportModalProps) {
 												className="mt-0.5"
 											/>
 											<div className="min-w-0 flex-1 select-none">
-												<p className="text-sm font-semibold text-gray-900">{row.name}</p>
+												<div className="flex items-start justify-between gap-2">
+													<p className="text-sm font-semibold text-gray-900">{row.name}</p>
+													<ProviderCatalogOutboundLink
+														links={row.links}
+														stopPropagation
+														className="inline-flex shrink-0 items-center gap-1 text-xs font-medium text-blue-700 hover:text-blue-800"
+													/>
+												</div>
 												<p className="text-xs text-gray-500">
 													{row.vendor_label} · {t('protocols')}: {row.protocols.join(', ') || '—'}
 												</p>

--- a/packages/admin/app/gateway/providers/components/provider-modal.tsx
+++ b/packages/admin/app/gateway/providers/components/provider-modal.tsx
@@ -9,6 +9,7 @@ import {
 import { useTranslations } from "next-intl";
 import { useEffect, useId, useState } from "react";
 import { protocolFormHasOverrides, protocolFormIsConfigured } from "../provider-utils";
+import { lookupStaticProviderCatalogLinks } from "@/lib/provider-import-preset";
 import type { UpstreamProtocol } from "@octafuse/core/upstream-protocol";
 import type {
 	GatewayProvider,
@@ -16,6 +17,7 @@ import type {
 	ProviderFormData,
 	ProviderProtocolSummary,
 } from "../types";
+import { ProviderCatalogOutboundLink } from "./provider-catalog-outbound-link";
 import { ProviderProtocolIcon } from "./provider-protocol-icon";
 
 type ProviderModalProps = {
@@ -509,9 +511,20 @@ export function ProviderModal(props: ProviderModalProps) {
 									/>
 								</div>
 								<div>
-									<label className="mb-1 block text-sm font-medium text-gray-700">
-										{editingProvider ? t("apiKeyOptional") : t("apiKeyRequired")}
-									</label>
+									<div className="mb-1 flex items-center justify-between gap-2">
+										<label className="block text-sm font-medium text-gray-700">
+											{editingProvider ? t("apiKeyOptional") : t("apiKeyRequired")}
+										</label>
+										<ProviderCatalogOutboundLink
+											links={
+												lookupStaticProviderCatalogLinks({
+													name: formData.name,
+													endpoints: editingProvider?.endpoints,
+												}) ?? editingProvider?.catalog_links
+											}
+											className="inline-flex items-center gap-1 text-xs font-medium text-blue-700 hover:text-blue-800"
+										/>
+									</div>
 									<input
 										type="password"
 										value={formData.api_key}

--- a/packages/admin/app/gateway/providers/types.ts
+++ b/packages/admin/app/gateway/providers/types.ts
@@ -30,6 +30,11 @@ export type ProviderImportCatalogRow = {
 	protocols: UpstreamProtocol[];
 	endpoints: string | null;
 	description: string | null;
+	links?: {
+		platform?: string;
+		api_keys?: string;
+		referral?: string;
+	};
 };
 
 export type ProviderProtocolSummary = {

--- a/packages/admin/components/model-vendor-icon.tsx
+++ b/packages/admin/components/model-vendor-icon.tsx
@@ -31,6 +31,7 @@ const VENDOR_VISUALS: Record<string, IconVisual> = {
 	deepinfra: { url: vendorIconAssets.deepinfra, accent: '#0ea5e9' },
 	deepseek: { url: vendorIconAssets.deepseek, accent: '#4d6bfe' },
 	fireworks: { url: vendorIconAssets.fireworks, accent: '#ff5f56' },
+	flatkey: { accent: '#2563eb' },
 	google: { url: vendorIconAssets.google, accent: '#4285f4' },
 	groq: { url: vendorIconAssets.groq, accent: '#f55036' },
 	huggingface: { url: vendorIconAssets.huggingface, accent: '#ff9d00' },

--- a/packages/admin/lib/model-vendors.json
+++ b/packages/admin/lib/model-vendors.json
@@ -12,6 +12,7 @@
   { "key": "deepinfra", "label": "DeepInfra" },
   { "key": "deepseek", "label": "DeepSeek" },
   { "key": "fireworks", "label": "Fireworks AI" },
+  { "key": "flatkey", "label": "Flatkey" },
   { "key": "google", "label": "Google" },
   { "key": "groq", "label": "Groq" },
   { "key": "huggingface", "label": "Hugging Face" },

--- a/packages/admin/lib/provider-import-preset.ts
+++ b/packages/admin/lib/provider-import-preset.ts
@@ -46,13 +46,25 @@ export type StaticProviderImportPresetRow = {
 			zh: { name: string; description: string };
 			en: { name: string; description: string };
 		};
-		links?: {
-			/** Provider 官方平台、控制台或本地产品下载页。 */
-			platform?: string;
-			/** 可确认稳定时填写的 API Key 管理直达页。 */
-			api_keys?: string;
-		};
+		links?: ProviderCatalogLinks;
 	};
+};
+
+/** 公开 Catalog / Admin 出站链接；不写入 providers 表。 */
+export type ProviderCatalogLinks = {
+	/** Provider 官方平台、控制台或本地产品下载页。 */
+	platform?: string;
+	/** 可确认稳定时填写的 API Key 管理直达页。 */
+	api_keys?: string;
+	/** 可选邀请/注册链接；出站 CTA 优先于 api_keys / platform。 */
+	referral?: string;
+};
+
+export type ProviderCatalogOutboundKind = 'referral' | 'api_keys' | 'platform';
+
+export type ProviderCatalogOutbound = {
+	href: string;
+	kind: ProviderCatalogOutboundKind;
 };
 
 /** 运行时 catalog 行键（JSON 数组下标字符串）；与入库 provider id 无关。 */
@@ -99,6 +111,44 @@ const STATIC_IDENTITY_BY_ENDPOINTS = new Map(
 	STATIC_ROWS.map((row) => [providerEndpointSignature(row.endpoints), identityForPreset(row)]).filter(
 		(entry): entry is [string, ProviderCatalogIdentity] => Boolean(entry[0])
 	)
+);
+
+function httpsHref(value: string | undefined | null): string | null {
+	const trimmed = String(value ?? '').trim();
+	if (!trimmed) return null;
+	try {
+		const url = new URL(trimmed);
+		return url.protocol === 'https:' ? trimmed : null;
+	} catch {
+		return null;
+	}
+}
+
+function catalogLinksFromRow(row: StaticProviderImportPresetRow): ProviderCatalogLinks | null {
+	const links = row.catalog?.links;
+	if (!links) return null;
+	const out: ProviderCatalogLinks = {};
+	const platform = httpsHref(links.platform);
+	const apiKeys = httpsHref(links.api_keys);
+	const referral = httpsHref(links.referral);
+	if (platform) out.platform = platform;
+	if (apiKeys) out.api_keys = apiKeys;
+	if (referral) out.referral = referral;
+	return platform || apiKeys || referral ? out : null;
+}
+
+const STATIC_LINKS_BY_NAME = new Map(
+	STATIC_ROWS.flatMap((row) => {
+		const links = catalogLinksFromRow(row);
+		return links ? ([[row.name.trim().toLowerCase(), links]] as const) : [];
+	})
+);
+const STATIC_LINKS_BY_ENDPOINTS = new Map(
+	STATIC_ROWS.flatMap((row) => {
+		const links = catalogLinksFromRow(row);
+		const signature = providerEndpointSignature(row.endpoints);
+		return links && signature ? ([[signature, links]] as const) : [];
+	})
 );
 
 function normalizedImportedProviderName(name: string | null | undefined): string {
@@ -158,6 +208,7 @@ function endpointIdentity(url: URL): ProviderCatalogIdentity | null {
 		['x.ai', identity('xai')],
 		['together.xyz', identity('together')],
 		['fireworks.ai', identity('fireworks')],
+		['flatkey.ai', identity('flatkey')],
 		['deepinfra.com', identity('deepinfra')],
 		['novita.ai', identity('novita')],
 		['huggingface.co', identity('huggingface')],
@@ -179,6 +230,7 @@ function endpointIdentity(url: URL): ProviderCatalogIdentity | null {
 		['zenmux.ai', identity('zenmux')],
 		['openrouter.ai', identity('openrouter')],
 		['siliconflow.cn', identity('siliconflow')],
+		['siliconflow.com', identity('siliconflow')],
 	];
 	for (const [domain, matchedIdentity] of domainRules) {
 		if (hostnameMatches(hostname, domain)) return matchedIdentity;
@@ -282,6 +334,7 @@ function identityFromNameHint(normalizedName: string): ProviderCatalogIdentity |
 		[['x.ai', 'xai', 'grok'], identity('xai')],
 		[['together'], identity('together')],
 		[['fireworks'], identity('fireworks')],
+		[['flatkey'], identity('flatkey')],
 		[['deepinfra', 'deep infra'], identity('deepinfra')],
 		[['novita'], identity('novita')],
 		[['huggingface', 'hugging face'], identity('huggingface')],
@@ -349,6 +402,38 @@ export function inferStaticProviderIconKey(provider: {
 	return inferStaticProviderIdentity(provider)?.iconKey ?? normalizeModelVendorInput(provider.vendor_key);
 }
 
+/**
+ * 按精确模板名（忽略导入去重后缀）或 endpoint 签名取 catalog 链接。
+ * 不按厂商域名回退，避免 OpenCode Zen / Go 等共用域名的模板串台。
+ */
+export function lookupStaticProviderCatalogLinks(provider: {
+	name?: string | null;
+	endpoints?: ProviderEndpointsSource['endpoints'];
+}): ProviderCatalogLinks | null {
+	const exactName = STATIC_LINKS_BY_NAME.get(normalizedImportedProviderName(provider.name));
+	if (exactName) return exactName;
+	const signature = providerEndpointSignature(provider.endpoints);
+	return (signature && STATIC_LINKS_BY_ENDPOINTS.get(signature)) || null;
+}
+
+/** 出站 CTA：邀请链接优先，其次密钥页，再次官网。 */
+export function resolveProviderCatalogOutbound(
+	links: ProviderCatalogLinks | null | undefined
+): ProviderCatalogOutbound | null {
+	if (!links) return null;
+	const referral = httpsHref(links.referral);
+	if (referral) return { href: referral, kind: 'referral' };
+	const apiKeys = httpsHref(links.api_keys);
+	if (apiKeys) return { href: apiKeys, kind: 'api_keys' };
+	const platform = httpsHref(links.platform);
+	if (platform) return { href: platform, kind: 'platform' };
+	return null;
+}
+
+export function providerCatalogOutboundRel(kind: ProviderCatalogOutboundKind): string {
+	return kind === 'referral' ? 'sponsored noopener noreferrer' : 'noopener noreferrer';
+}
+
 function protocolsForPreset(p: StaticProviderImportPresetRow): AdminProviderImportCatalogItem['protocols'] {
 	const map = parseProviderEndpoints({ endpoints: p.endpoints });
 	const out: AdminProviderImportCatalogItem['protocols'] = [];
@@ -399,6 +484,7 @@ export function listStaticProviderImportCatalogForAdmin(): AdminProviderImportCa
 			protocols: protocolsForPreset(p),
 			endpoints: serializeProviderEndpoints(map),
 			description: p.description != null && String(p.description).trim() ? String(p.description).trim() : null,
+			links: catalogLinksFromRow(p) ?? undefined,
 		};
 	});
 }

--- a/packages/admin/lib/provider-import-presets.json
+++ b/packages/admin/lib/provider-import-presets.json
@@ -1348,6 +1348,45 @@
 		}
 	},
 	{
+		"name": "Flatkey",
+		"vendor_key": "flatkey",
+		"endpoints": {
+			"openai": {
+				"endpoints": {
+					"chat": "https://router.flatkey.ai/v1/chat/completions",
+					"responses": "https://router.flatkey.ai/v1/responses",
+					"images.generations": "https://router.flatkey.ai/v1/images/generations",
+					"images.edits": "https://router.flatkey.ai/v1/images/edits"
+				}
+			},
+			"anthropic": {
+				"base": "https://router.flatkey.ai"
+			},
+			"gemini": {
+				"base": "https://router.flatkey.ai/v1beta/models",
+				"auth": "bearer"
+			}
+		},
+		"description": "Flatkey router (router.flatkey.ai): OpenAI chat/completions + responses + images/generations + images/edits (capability URLs only—do not set openai.base or Gateway would derive undocumented audio paths); Anthropic Messages (root appends /v1/messages); Gemini native generateContent (/v1beta/models, Bearer). Video (/v1/videos) is not configured by this template. See docs.flatkey.ai.",
+		"catalog": {
+			"i18n": {
+				"zh": {
+					"name": "Flatkey",
+					"description": "Flatkey 聚合网关，支持 OpenAI、Anthropic 与原生 Gemini，覆盖对话与图片。"
+				},
+				"en": {
+					"name": "Flatkey",
+					"description": "Flatkey aggregation gateway with OpenAI, Anthropic, and native Gemini for chat and images."
+				}
+			},
+			"links": {
+				"platform": "https://flatkey.ai/",
+				"api_keys": "https://console.flatkey.ai/keys",
+				"referral": "https://console.flatkey.ai/sign-up?aff=Pu3g"
+			}
+		}
+	},
+	{
 		"name": "OpenCode Zen",
 		"vendor_key": "opencode",
 		"endpoints": {
@@ -1529,7 +1568,8 @@
 			},
 			"links": {
 				"platform": "https://zenmux.ai/",
-				"api_keys": "https://zenmux.ai/platform"
+				"api_keys": "https://zenmux.ai/platform",
+				"referral": "https://zenmux.ai/invite/PNWNOJ"
 			}
 		}
 	},
@@ -1572,20 +1612,48 @@
 				"base": "https://api.siliconflow.cn/v1"
 			}
 		},
+		"description": "China SiliconFlow Model Cloud (api.siliconflow.cn). Do not mix with international api.siliconflow.com keys or cloud.siliconflow.com accounts.",
 		"catalog": {
 			"i18n": {
 				"zh": {
 					"name": "硅基流动",
-					"description": "硅基流动模型云的 OpenAI 兼容 API。"
+					"description": "硅基流动国内站的 OpenAI 兼容 API。"
 				},
 				"en": {
 					"name": "SiliconFlow",
-					"description": "SiliconFlow Model Cloud’s OpenAI-compatible API."
+					"description": "SiliconFlow China Model Cloud’s OpenAI-compatible API."
 				}
 			},
 			"links": {
 				"platform": "https://cloud.siliconflow.cn/",
-				"api_keys": "https://cloud.siliconflow.cn/account/ak"
+				"api_keys": "https://cloud.siliconflow.cn/account/ak",
+				"referral": "https://cloud.siliconflow.cn/i/rA30k5VJ"
+			}
+		}
+	},
+	{
+		"name": "SiliconFlow (International)",
+		"vendor_key": "siliconflow",
+		"endpoints": {
+			"openai": {
+				"base": "https://api.siliconflow.com/v1"
+			}
+		},
+		"description": "International SiliconFlow (api.siliconflow.com / cloud.siliconflow.com). Not for mainland China accounts; do not mix with api.siliconflow.cn keys.",
+		"catalog": {
+			"i18n": {
+				"zh": {
+					"name": "硅基流动（国际站）",
+					"description": "硅基流动国际站的 OpenAI 兼容 API。"
+				},
+				"en": {
+					"name": "SiliconFlow (International)",
+					"description": "SiliconFlow’s international Model Cloud OpenAI-compatible API."
+				}
+			},
+			"links": {
+				"platform": "https://cloud.siliconflow.com/",
+				"api_keys": "https://cloud.siliconflow.com/account/ak"
 			}
 		}
 	},

--- a/packages/admin/lib/services/admin/provider-import-preset.test.ts
+++ b/packages/admin/lib/services/admin/provider-import-preset.test.ts
@@ -4,6 +4,9 @@ import {
 	inferStaticProviderIconKey,
 	inferStaticProviderVendorKey,
 	listStaticProviderImportPresets,
+	lookupStaticProviderCatalogLinks,
+	providerCatalogOutboundRel,
+	resolveProviderCatalogOutbound,
 } from '@/lib/provider-import-preset';
 import type { ProviderEndpointsMap } from '@octafuse/core/provider-endpoints';
 
@@ -60,6 +63,9 @@ describe('provider import preset catalog metadata', () => {
 			assert.match(row.catalog?.links?.platform ?? '', /^https:\/\//, row.name);
 			if (row.catalog?.links?.api_keys) {
 				assert.match(row.catalog.links.api_keys, /^https:\/\//, row.name);
+			}
+			if (row.catalog?.links?.referral) {
+				assert.match(row.catalog.links.referral, /^https:\/\//, row.name);
 			}
 		}
 	});
@@ -206,6 +212,41 @@ describe('provider import preset catalog metadata', () => {
 		);
 		assert.equal(chatOf('SCNet'), 'https://api.scnet.cn/api/llm/v1/chat/completions');
 		assert.equal(anthropicBaseOf('SCNet'), 'https://api.scnet.cn/api/llm/anthropic');
+		assert.equal(chatOf('Flatkey'), 'https://router.flatkey.ai/v1/chat/completions');
+		assert.equal(
+			byName.get('Flatkey')?.endpoints.openai?.endpoints?.responses,
+			'https://router.flatkey.ai/v1/responses'
+		);
+		assert.equal(
+			byName.get('Flatkey')?.endpoints.openai?.endpoints?.['images.generations'],
+			'https://router.flatkey.ai/v1/images/generations'
+		);
+		assert.equal(
+			byName.get('Flatkey')?.endpoints.openai?.endpoints?.['images.edits'],
+			'https://router.flatkey.ai/v1/images/edits'
+		);
+		assert.equal(byName.get('Flatkey')?.endpoints.openai?.base, undefined);
+		assert.equal(anthropicBaseOf('Flatkey'), 'https://router.flatkey.ai');
+		assert.equal(
+			byName.get('Flatkey')?.endpoints.gemini?.base,
+			'https://router.flatkey.ai/v1beta/models'
+		);
+		assert.equal(byName.get('Flatkey')?.endpoints.gemini?.auth, 'bearer');
+		assert.equal(
+			byName.get('Flatkey')?.catalog?.links?.referral,
+			'https://console.flatkey.ai/sign-up?aff=Pu3g'
+		);
+		assert.equal(openaiBaseOf('SiliconFlow'), 'https://api.siliconflow.cn/v1');
+		assert.equal(
+			byName.get('SiliconFlow')?.catalog?.links?.referral,
+			'https://cloud.siliconflow.cn/i/rA30k5VJ'
+		);
+		assert.equal(openaiBaseOf('SiliconFlow (International)'), 'https://api.siliconflow.com/v1');
+		assert.equal(byName.get('SiliconFlow (International)')?.catalog?.links?.referral, undefined);
+		assert.equal(
+			byName.get('SiliconFlow (International)')?.catalog?.links?.platform,
+			'https://cloud.siliconflow.com/'
+		);
 	});
 
 	it('keeps Vertex Express on Gemini query-key and adds project-scoped OpenAI chat', () => {
@@ -247,5 +288,108 @@ describe('provider import preset catalog metadata', () => {
 
 		assert.equal(inferStaticProviderVendorKey(conflicting), 'other');
 		assert.equal(inferStaticProviderIconKey(conflicting), 'other');
+	});
+
+	it('overlays catalog links by template name or endpoint signature, preferring referral', () => {
+		const rows = listStaticProviderImportPresets();
+		const flatkey = rows.find((row) => row.name === 'Flatkey');
+		const zen = rows.find((row) => row.name === 'OpenCode Zen');
+		const go = rows.find((row) => row.name === 'OpenCode Go');
+		assert.ok(flatkey);
+		assert.ok(zen);
+		assert.ok(go);
+
+		assert.deepEqual(lookupStaticProviderCatalogLinks({ name: 'Flatkey (2)' }), {
+			platform: 'https://flatkey.ai/',
+			api_keys: 'https://console.flatkey.ai/keys',
+			referral: 'https://console.flatkey.ai/sign-up?aff=Pu3g',
+		});
+		assert.deepEqual(
+			lookupStaticProviderCatalogLinks({
+				name: 'Renamed production upstream',
+				endpoints: flatkey.endpoints,
+			}),
+			lookupStaticProviderCatalogLinks({ name: 'Flatkey' })
+		);
+		assert.equal(
+			lookupStaticProviderCatalogLinks({
+				name: 'Private upstream',
+				endpoints: {
+					openai: { endpoints: { chat: 'https://example.com/v1/chat/completions' } },
+				},
+			}),
+			null
+		);
+
+		assert.equal(
+			lookupStaticProviderCatalogLinks({ name: zen.name })?.platform,
+			'https://opencode.ai/zen'
+		);
+		assert.equal(
+			lookupStaticProviderCatalogLinks({ name: go.name })?.platform,
+			'https://opencode.ai/go'
+		);
+
+		const outbound = resolveProviderCatalogOutbound(
+			lookupStaticProviderCatalogLinks({ name: 'Flatkey' })
+		);
+		assert.deepEqual(outbound, {
+			href: 'https://console.flatkey.ai/sign-up?aff=Pu3g',
+			kind: 'referral',
+		});
+		assert.deepEqual(resolveProviderCatalogOutbound(lookupStaticProviderCatalogLinks({ name: 'ZenMux' })), {
+			href: 'https://zenmux.ai/invite/PNWNOJ',
+			kind: 'referral',
+		});
+		assert.deepEqual(lookupStaticProviderCatalogLinks({ name: 'SiliconFlow' }), {
+			platform: 'https://cloud.siliconflow.cn/',
+			api_keys: 'https://cloud.siliconflow.cn/account/ak',
+			referral: 'https://cloud.siliconflow.cn/i/rA30k5VJ',
+		});
+		assert.deepEqual(lookupStaticProviderCatalogLinks({ name: 'SiliconFlow (International)' }), {
+			platform: 'https://cloud.siliconflow.com/',
+			api_keys: 'https://cloud.siliconflow.com/account/ak',
+		});
+		const siliconflowChina = rows.find((row) => row.name === 'SiliconFlow');
+		const siliconflowIntl = rows.find((row) => row.name === 'SiliconFlow (International)');
+		assert.ok(siliconflowChina);
+		assert.ok(siliconflowIntl);
+		assert.deepEqual(
+			lookupStaticProviderCatalogLinks({
+				name: 'Renamed production upstream',
+				endpoints: siliconflowChina.endpoints,
+			}),
+			lookupStaticProviderCatalogLinks({ name: 'SiliconFlow' })
+		);
+		assert.deepEqual(
+			lookupStaticProviderCatalogLinks({
+				name: 'Renamed production upstream',
+				endpoints: siliconflowIntl.endpoints,
+			}),
+			lookupStaticProviderCatalogLinks({ name: 'SiliconFlow (International)' })
+		);
+		assert.deepEqual(
+			resolveProviderCatalogOutbound(lookupStaticProviderCatalogLinks({ name: 'SiliconFlow' })),
+			{
+				href: 'https://cloud.siliconflow.cn/i/rA30k5VJ',
+				kind: 'referral',
+			}
+		);
+		assert.equal(
+			resolveProviderCatalogOutbound(
+				lookupStaticProviderCatalogLinks({ name: 'SiliconFlow (International)' })
+			)?.kind,
+			'api_keys'
+		);
+		assert.equal(providerCatalogOutboundRel('referral'), 'sponsored noopener noreferrer');
+		assert.equal(
+			resolveProviderCatalogOutbound({
+				platform: 'https://flatkey.ai/',
+				api_keys: 'https://console.flatkey.ai/keys',
+			})?.kind,
+			'api_keys'
+		);
+		assert.equal(resolveProviderCatalogOutbound({ platform: 'https://flatkey.ai/' })?.kind, 'platform');
+		assert.equal(resolveProviderCatalogOutbound({ referral: 'http://insecure.example' }), null);
 	});
 });

--- a/packages/admin/lib/services/admin/providers-service.ts
+++ b/packages/admin/lib/services/admin/providers-service.ts
@@ -14,6 +14,7 @@ import {
 	inferStaticProviderIconKey,
 	inferStaticProviderVendorKey,
 	listStaticProviderImportPresets,
+	lookupStaticProviderCatalogLinks,
 } from '@/lib/provider-import-preset';
 import { badRequest, conflict, notFound } from './errors';
 import type {
@@ -46,10 +47,12 @@ function normalizeProviderStatus(raw: unknown): 'active' | 'disabled' {
 function enrichProviderRow(provider: AdminProviderRow): AdminProviderRow {
 	const plaintext = typeof provider.api_key === 'string' ? provider.api_key : '';
 	const vendorKey = inferStaticProviderVendorKey(provider);
+	const catalogLinks = lookupStaticProviderCatalogLinks(provider);
 	return {
 		...provider,
 		vendor_key: vendorKey,
 		icon_key: inferStaticProviderIconKey({ ...provider, vendor_key: vendorKey }),
+		catalog_links: catalogLinks ?? undefined,
 		api_key: maskProviderApiKeyForAdmin(plaintext),
 		status: provider.status === 'disabled' ? 'disabled' : 'active',
 		has_pending_key: isPendingProviderImportApiKey(plaintext),

--- a/packages/admin/lib/services/admin/types.ts
+++ b/packages/admin/lib/services/admin/types.ts
@@ -128,6 +128,12 @@ export type AdminProviderImportCatalogItem = {
 	/** 序列化后的 endpoints JSON（可 null） */
 	endpoints: string | null;
 	description: string | null;
+	/** 官网 / 密钥页 / 可选邀请链接；不写入 providers 表。 */
+	links?: {
+		platform?: string;
+		api_keys?: string;
+		referral?: string;
+	};
 };
 
 /** `POST /admin/providers/import` 请求体：导入选中的 catalog 键（`GET .../catalog` 返回的 `id`）。 */
@@ -250,6 +256,12 @@ export type AdminProviderRow = {
 	vendor_key?: string;
 	/** 由内置 Provider 预设动态推导的产品级图标，不持久化。 */
 	icon_key?: string;
+	/** 由内置预设叠加的官网 / 密钥 / 邀请链接，不持久化。 */
+	catalog_links?: {
+		platform?: string;
+		api_keys?: string;
+		referral?: string;
+	};
 	endpoints: string | null;
 	/** 列表/详情为脱敏预览；明文仅经 `GET /:id/api-key` */
 	api_key?: string;

--- a/packages/admin/lib/types.ts
+++ b/packages/admin/lib/types.ts
@@ -136,6 +136,12 @@ export interface GatewayProvider {
   vendor_key?: string;
   /** Admin API 根据内置预设动态推导的产品级图标；不写入 providers 表。 */
   icon_key?: string;
+  /** Admin API 根据内置预设叠加的官网 / 密钥 / 邀请链接；不写入 providers 表。 */
+  catalog_links?: {
+    platform?: string;
+    api_keys?: string;
+    referral?: string;
+  };
   /** 协议端点 JSON；见 `providers.endpoints` */
   endpoints?: string | null;
   /** 脱敏预览；明文仅经 `GET /admin/providers/:id/api-key` */

--- a/packages/admin/messages/en.json
+++ b/packages/admin/messages/en.json
@@ -384,6 +384,9 @@
 			"failed": "Import failed",
 			"copyFailed": "Failed to copy API key"
 		},
+		"outbound": {
+			"go": "Click to go"
+		},
 		"modal": {
 			"editTitle": "Edit Provider",
 			"newTitle": "New Provider",

--- a/packages/admin/messages/ja.json
+++ b/packages/admin/messages/ja.json
@@ -384,6 +384,9 @@
 			"failed": "インポートに失敗しました",
 			"copyFailed": "API Key のコピーに失敗しました"
 		},
+		"outbound": {
+			"go": "クリックして開く"
+		},
 		"modal": {
 			"editTitle": "Provider を編集",
 			"newTitle": "新しい Provider",

--- a/packages/admin/messages/ko.json
+++ b/packages/admin/messages/ko.json
@@ -384,6 +384,9 @@
 			"failed": "가져오기에 실패했습니다",
 			"copyFailed": "API Key 복사에 실패했습니다"
 		},
+		"outbound": {
+			"go": "클릭하여 이동"
+		},
 		"modal": {
 			"editTitle": "Provider 편집",
 			"newTitle": "새 Provider",

--- a/packages/admin/messages/zh.json
+++ b/packages/admin/messages/zh.json
@@ -384,6 +384,9 @@
 			"failed": "导入失败",
 			"copyFailed": "复制 API Key 失败"
 		},
+		"outbound": {
+			"go": "点击前往"
+		},
 		"modal": {
 			"editTitle": "编辑供应商",
 			"newTitle": "新建供应商",


### PR DESCRIPTION
- Introduced the Flatkey provider with specific endpoints for OpenAI, Anthropic, and Gemini, including detailed descriptions and capabilities.
- Enhanced the provider import presets to include catalog links for platform, API keys, and referral, ensuring better user navigation.
- Updated the admin components to display catalog links in provider cards and modals, improving accessibility to relevant resources.
- Revised types and tests to accommodate the new Flatkey provider and its associated catalog links, ensuring robust functionality and coverage.

## Summary

<!-- What does this PR change and why? -->

## Target branch

<!-- Normal features/contributions target develop. Releases use release/X.Y.Z when a freeze branch is needed; current-release hotfixes use hotfix/X.Y.Z and target main. -->

- [ ] This PR targets `develop`, or a maintainer has confirmed `main` / another base branch for a release or hotfix.

## Type of change

<!-- Check all that apply -->

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change (describe migration / release notes impact)
- [ ] Documentation only
- [ ] Build / CI / chore

## Checklist

- [ ] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) (including the contribution license terms).
- [ ] For user-visible behavior or API changes, I updated docs where appropriate.
- [ ] I added a changeset for user-visible changes, or documented why it is deferred / unnecessary.
- [ ] I ran relevant tests or smoke scripts locally when applicable (e.g. `npm run test:gateway:postgres-smoke`).

## Related issues

<!-- Link e.g. Fixes #123 -->
