### PR TITLE
feat: add Gemini 3.8 Flash model preset with pricing and capabilities

### DIFF
--- a/packages/admin/lib/model-presets/google.json
+++ b/packages/admin/lib/model-presets/google.json
@@ -1,5 +1,54 @@
 [
 	{
+		"id": "gemini-3.8-flash",
+		"display_name": "Gemini 3.8 Flash",
+		"description": "Our most intelligent Flash model, engineered for long-horizon software engineering, autonomous agents, and complex enterprise workflows. It improves software engineering, agentic tasks, and multi-step reasoning over Gemini 3.7 Flash.",
+		"i18n": {
+			"en": "Our most intelligent Flash model, engineered for long-horizon software engineering, autonomous agents, and complex enterprise workflows. It improves software engineering, agentic tasks, and multi-step reasoning over Gemini 3.7 Flash.",
+			"zh": "面向长周期软件工程、自主 Agent 与复杂企业工作流的最强 Gemini Flash 模型。相较 Gemini 3.7 Flash，提升软件工程、Agent 任务与多步推理能力。"
+		},
+		"vendor": "google",
+		"context_window": 1000000,
+		"max_tokens": 64000,
+		"pricing": {
+			"usd": {
+				"tiers": [
+					{
+						"upto": null,
+						"input_price": 0.75,
+						"output_price": 3.75,
+						"cache_read_price": 0.075,
+						"cache_write_price": 0.08333
+					}
+				]
+			},
+			"cny": {
+				"tiers": [
+					{
+						"upto": null,
+						"input_price": 5.25,
+						"output_price": 26.25,
+						"cache_read_price": 0.525,
+						"cache_write_price": 0.58331
+					}
+				]
+			}
+		},
+		"modalities": {
+			"input": [
+				"text",
+				"image",
+				"audio",
+				"video",
+				"file"
+			],
+			"output": [
+				"text"
+			]
+		},
+		"released": "2026-09-02"
+	},
+	{
 		"id": "gemini-3.7-flash",
 		"display_name": "Gemini 3.7 Flash",
 		"description": "A high-efficiency Gemini workhorse for coding, agents, and knowledge work. It improves first-pass code accuracy, multi-step tool use, and production-ready application output over Gemini 3.6 Flash.",

--- a/packages/admin/lib/services/admin/import-catalog-billing.test.ts
+++ b/packages/admin/lib/services/admin/import-catalog-billing.test.ts
@@ -57,6 +57,18 @@ describe('import catalog pricing preview follows billing currency', () => {
 		assert.equal(cny!.pricing_label, '¥6 / ¥18 /M');
 	});
 
+	it('includes gemini-3.8-flash with current Gemini API introductory prices', () => {
+		const usd = listStaticModelPresetCatalogForAdmin('USD').find((r) => r.id === 'gemini-3.8-flash');
+		const cny = listStaticModelPresetCatalogForAdmin('CNY').find((r) => r.id === 'gemini-3.8-flash');
+		assert.ok(usd);
+		assert.ok(cny);
+		assert.equal(usd!.display_name, 'Gemini 3.8 Flash');
+		assert.equal(usd!.context_window, 1000000);
+		assert.equal(usd!.max_tokens, 64000);
+		assert.equal(usd!.pricing_label, '$0.75 / $3.75 /M');
+		assert.equal(cny!.pricing_label, '¥5.25 / ¥26.25 /M');
+	});
+
 	it('includes qwen3.8-flash with official Model Studio list prices', () => {
 		const usd = listStaticModelPresetCatalogForAdmin('USD').find((r) => r.id === 'qwen3.8-flash');
 		const cny = listStaticModelPresetCatalogForAdmin('CNY').find((r) => r.id === 'qwen3.8-flash');


### PR DESCRIPTION
- Introduced the Gemini 3.8 Flash model preset, enhancing the catalog with detailed descriptions, pricing tiers in USD and CNY, and supported modalities.
- Updated tests to include the new model preset, ensuring accurate representation of its features and pricing in the admin interface.

## Summary

<!-- What does this PR change and why? -->

## Target branch

<!-- Normal features/contributions target develop. Releases use release/X.Y.Z when a freeze branch is needed; current-release hotfixes use hotfix/X.Y.Z and target main. -->

- [ ] This PR targets `develop`, or a maintainer has confirmed `main` / another base branch for a release or hotfix.

## Type of change

<!-- Check all that apply -->

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change (describe migration / release notes impact)
- [ ] Documentation only
- [ ] Build / CI / chore

## Checklist

- [ ] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) (including the contribution license terms).
- [ ] For user-visible behavior or API changes, I updated docs where appropriate.
- [ ] I added a changeset for user-visible changes, or documented why it is deferred / unnecessary.
- [ ] I ran relevant tests or smoke scripts locally when applicable (e.g. `npm run test:gateway:postgres-smoke`).

## Related issues

<!-- Link e.g. Fixes #123 -->
