### PR TITLE
refactor(api): update rate limit documentation and logic for users an…

### DIFF
--- a/docs/developers/api/admin.md
+++ b/docs/developers/api/admin.md
@@ -149,7 +149,7 @@ Authorization: Bearer sk-admin-<64 hex characters>
 
 更新邮箱、预算计划、`status`、`metadata`（合并或 `metadata_replace`）、外部身份对、`charged_cost_factors`（对象或 `null`，校验规则与创建相同）、`wallet_granted` / `wallet_spent`（永久额度绝对值，运维修正）、`rate_limit`（用户层 JSON，与 Key 同形状；`null` 表示该层不限）等。仅改用户计费倍率时，审计 `reason_code` 为 `admin_patch_charged_cost_factors`；仅改用户限流时为 `admin_patch_rate_limit`。**密钥级字段不可在此修改**（密钥 `rate_limit` 走 `PATCH /admin/keys/:id`）。加购增量请用下方 **`wallet/credit`**，不要把金额加进 `budget_max`。
 
-`users.rate_limit` 是该用户**所有 Key 合计**的共享池，不会复制到新建 Key，也不要求 `key.rpm <= user.rpm`。只限制某一把钥匙时，只写该 Key 的 `rate_limit`，用户层保持 `null`。
+`users.rate_limit` 是该用户**所有 Key 合计**的共享池，不会复制到新建 Key，也不要求 `key.rpm <= user.rpm`。只限制某一把钥匙时，只写该 Key 的 `rate_limit`，用户层保持 `null`。Key 层与 User 层的 `rpm` 都是从当前时刻回溯 60 秒的滚动窗口，不是 UTC 自然分钟。
 
 用于**绝对值**设置、运维修正、取消/到期回收等不依赖当前预算快照的变更。若需基于当前 `budget_max/budget_spent` 计算结转并原子写入，请使用下方 **`budget/transition`**。
 
@@ -407,7 +407,7 @@ PATCH /admin/keys/:id
 | `status` | 可选；如 `active`、`revoked` |
 | `metadata` | 可选；**对象**时与现有 key `metadata` **合并**；**字符串**时视为整段替换（与 `metadata_replace` 语义相同） |
 | `metadata_replace` | 可选；JSON 字符串，整段替换 metadata；勿与对象形式的 `metadata` 同时使用 |
-| `rate_limit` | 可选；JSON 对象。`null` 表示该 Key 不限。当前仅支持 `rpm`（非负整数，该 Key 每 60 秒窗口内允许的请求数；`0` 拒绝所有计次请求）。与用户层 `users.rate_limit` **双重执行**，两者都要通过；超限仍返回同一 `429` + `gateway.rate_limited`（不区分哪一层）。`GET /v1/me` 两层都不计入。计数在代理服务进程内存中（多 isolate / 多副本为软上限）。省略则不改 |
+| `rate_limit` | 可选；JSON 对象。`null` 表示该 Key 不限。当前仅支持 `rpm`（非负整数，该 Key 从当前时刻回溯 60 秒的滚动窗口内允许的请求数；`0` 拒绝所有计次请求）。与用户层 `users.rate_limit` **双重执行**（两层都是回溯 60 秒，各自独立计数），两者都要通过；超限仍返回同一 `429` + `gateway.rate_limited`（不区分哪一层）。`GET /v1/me` 两层都不计入。计数在代理服务进程内存中（多 isolate / 多副本为软上限）。省略则不改 |
 | `reason` | 可选；写入用户审计等文案，缺省由服务端默认 |
 
 ### 响应

--- a/docs/developers/api/user.md
+++ b/docs/developers/api/user.md
@@ -61,7 +61,7 @@ Gateway 会根据 `model_id + route_group + request_protocol + request_operation
 
 ### 4. 请求限流（Key / 用户 RPM）
 
-鉴权后对 **Key 窗口**与 **用户合计窗口**双重执行（先 Key 后 User；Key 已超限则不消耗用户窗口）。两层 JSON 形状相同，当前仅 `rpm`（每 60 秒滚动窗口请求上限）：`NULL` / 空对象该层不限，`rpm: 0` 拒绝该层计次请求。两层独立，不把用户配置复制到新建 Key。超限返回 **429** `gateway.rate_limited`（含 `Retry-After`），**不区分**是哪一层。计数在代理服务进程 / isolate 内存中，属软上限。
+鉴权后对 **Key 窗口**与 **用户合计窗口**双重执行（先 Key 后 User；Key 已超限则不消耗用户窗口）。两层 JSON 形状相同，当前仅 `rpm`（从当前时刻回溯 60 秒的滚动窗口请求上限，**不是** UTC 自然分钟）：`NULL` / 空对象该层不限，`rpm: 0` 拒绝该层计次请求。两层独立计数，不把用户配置复制到新建 Key。超限返回 **429** `gateway.rate_limited`（含 `Retry-After`，等到该层窗口内有空位），**不区分**是哪一层。计数在代理服务进程 / isolate 内存中，属软上限。
 
 `GET /v1/me` **两层都不计入**。`GET /v1/models` 与其它 `/v1/*` 会计入（若对应层配置了 `rpm`）。配置入口为管理后台用户详情的用户合计 RPM，以及密钥（Keys）页的单 Key RPM；API 见 [admin.md](./admin.md) 的 `PATCH /admin/users/:id` 与 `PATCH /admin/keys/:id`。
 

--- a/docs/developers/architecture/proxy-request-lifecycle.md
+++ b/docs/developers/architecture/proxy-request-lifecycle.md
@@ -95,7 +95,7 @@ flowchart TB
 
 ### 2.1 鉴权与解析
 
-1. **`requireApiKey`**：从 `Authorization: Bearer sk-...`、`x-api-key` 或 query `key` 提取密钥；`authenticateApiKey` 查库并注入 `c.set('apiKey')`（含 `userId`、`budgetMax`、`budgetSpent`、`walletGranted`、`walletSpent` 等）。若 Key 或用户配置了 `rate_limit.rpm`，先消耗 Key 窗口再消耗用户合计窗口；超限返回 **429** `gateway.rate_limited`。`GET /v1/me` 两层都不计入。
+1. **`requireApiKey`**：从 `Authorization: Bearer sk-...`、`x-api-key` 或 query `key` 提取密钥；`authenticateApiKey` 查库并注入 `c.set('apiKey')`（含 `userId`、`budgetMax`、`budgetSpent`、`walletGranted`、`walletSpent` 等）。若 Key 或用户配置了 `rate_limit.rpm`，先消耗 Key 窗口再消耗用户合计窗口（两层都是从当前时刻回溯 60 秒）；超限返回 **429** `gateway.rate_limited`。`GET /v1/me` 两层都不计入。
 2. **解析 JSON body**：非法 JSON → **400**；缺少 `model` → **400**。
 3. **`resolveModelRouting`**：支持 `baseModelId` 或 `baseModelId:route_group`；模型不存在 → **404**。
 4. **用户额度**：`hasPositiveTotalBalance(budgetMax, budgetSpent, walletGranted, walletSpent)` 为假 → **403**。`budgetMax == null` 表示周期不限额；否则看周期剩余 + 永久余额。**`budgetMax=0` 且 wallet 仍有余额时允许请求**（勿用旧式 `budgetSpent >= budgetMax`，`0 >= 0` 会误杀）。

--- a/docs/developers/architecture/runtime-data.md
+++ b/docs/developers/architecture/runtime-data.md
@@ -184,8 +184,8 @@ sequenceDiagram
 | **`users.wallet_granted` / `wallet_spent`** | 永久额度累计发放 / 累计消耗；余额派生，不随周期重置或到期清零 |
 | **`user_audit_logs.dedup_key`** | 加额幂等键（`UNIQUE(user_id, dedup_key)`）；`wallet_credit` 用 `external_ref` |
 | **`api_key_request_logs.charged_wallet_cost`** | 本次请求从永久池扣掉的部分；周期部分 = `charged_cost − charged_wallet_cost` |
-| **`api_keys.rate_limit`** | 每 Key 限流 JSON；`NULL` 不限。当前 `rpm` 为每分钟请求上限，`0` 拒绝计次请求 |
-| **`users.rate_limit`** | 用户层限流 JSON（与 Key 同形状）；`NULL` 不限。当前 `rpm` 为该用户所有 Key 合计的每分钟上限 |
+| **`api_keys.rate_limit`** | 每 Key 限流 JSON；`NULL` 不限。当前 `rpm` 为从当前时刻回溯 60 秒的请求上限，`0` 拒绝计次请求 |
+| **`users.rate_limit`** | 用户层限流 JSON（与 Key 同形状）；`NULL` 不限。当前 `rpm` 为该用户所有 Key 合计、同样回溯 60 秒的上限 |
 | **`api_key_request_logs.ingress_host`** | 请求打到的入口 Host（只记录，不做准入） |
 
 已移除：`provider_api_keys`、`limit_config`（网关 RPM/TPM/并发软限流）、`models.sticky_config`（旧粘性 key 绑定；由路由池级 **供应商粘性** + `route_pool_sticky_bindings` 替代）。

--- a/docs/developers/architecture/user-keys-data-model.md
+++ b/docs/developers/architecture/user-keys-data-model.md
@@ -78,7 +78,7 @@ erDiagram
    - 删除 **`users`**：`ON DELETE CASCADE` 删除其 **`api_keys`**；子表中若存在指向该用户的 FK，按迁移定义处理（`user_audit_logs.user_id` 为 **`ON DELETE SET NULL`**，审计行保留）。
    - 删除 **`api_keys`**：**不**级联删除请求日志；`api_key_request_logs.api_key_id` 为 **`ON DELETE SET NULL`**，`user_id` 保留以便按用户维度统计历史。
 6. **`charged_cost_factors`**：可选 JSON，键为目录 `models.id`，值为 ≥ 0 的用户计费倍率；`null` / `{}` 落库为 NULL。鉴权 JOIN 会带上该列。LLM / Images / Audio 在路由用户计费算完后再乘；智能体工具不应用。
-7. **`users.rate_limit` / `api_keys.rate_limit`**：形状相同的 JSON（当前仅 `rpm`）。用户层是该用户所有 Key 的合计窗口；Key 层是单把钥匙的额外帽子。两层独立：不把用户配置复制到新建 Key，不要求 `key.rpm <= user.rpm`。`NULL` / 空 = 该层不限；`rpm: 0` 拒绝该层计次请求。同时设置时，单把 Key 的有效上限约为 `min(keyRpm, 用户池剩余)`。
+7. **`users.rate_limit` / `api_keys.rate_limit`**：形状相同的 JSON（当前仅 `rpm`）。用户层是该用户所有 Key 的合计窗口；Key 层是单把钥匙的额外帽子。两层都按**从当前时刻回溯 60 秒**独立计数（不是 UTC 自然分钟）。两层独立：不把用户配置复制到新建 Key，不要求 `key.rpm <= user.rpm`。`NULL` / 空 = 该层不限；`rpm: 0` 拒绝该层计次请求。同时设置时，单把 Key 的有效上限约为 `min(keyRpm, 用户池剩余)`。
 
 ## 请求日志与审计
 
@@ -87,7 +87,7 @@ erDiagram
 
 ## 关键读写路径（与实现对齐）
 
-- **鉴权**：`getApiKeyWithUserByKey` 单次 JOIN 读取 key + user 预算字段、`charged_cost_factors` 与 `users.rate_limit`；周期懒重置走 **`updateUserBudgetWithAuditTx`**（Postgres/MySQL 带 `budget_reset_at` 条件更新以避免并发重复审计）。鉴权后对 Key 窗口与用户合计窗口**双重执行**（先 Key 后 User；Key 已超限则不消耗用户窗口）。超限返回 `429` + `gateway.rate_limited`（不暴露是哪一层）。`GET /v1/me` 两层都不计入。内存 store 的 subject 前缀为 `k:` / `u:`。计数与熔断一样是单 isolate / 单进程软状态。
+- **鉴权**：`getApiKeyWithUserByKey` 单次 JOIN 读取 key + user 预算字段、`charged_cost_factors` 与 `users.rate_limit`；周期懒重置走 **`updateUserBudgetWithAuditTx`**（Postgres/MySQL 带 `budget_reset_at` 条件更新以避免并发重复审计）。鉴权后对 Key 窗口与用户合计窗口**双重执行**（先 Key 后 User；Key 已超限则不消耗用户窗口）。两层都是从当前时刻回溯 60 秒的滚动窗口。超限返回 `429` + `gateway.rate_limited`（不暴露是哪一层；`Retry-After` 取实际超限那一层）。`GET /v1/me` 两层都不计入。内存 store 的 subject 前缀为 `k:` / `u:`。计数与熔断一样是单 isolate / 单进程软状态。
 - **扣费**：`insertRequestUsageAndChargeTx` 在同一事务内 **`INSERT api_key_request_logs`**（含 `charged_wallet_cost`、`ingress_host`）+ **`UPDATE api_keys.last_used_at`** + **`UPDATE users SET budget_spent += Δ1, wallet_spent += Δ2`**（SQL 侧原子累加）+ **`INSERT user_audit_logs`**（`usage_charge`）。周期剩余不够时差额进永久池。
 - **加额**：`grantWalletCreditWithAuditTx` 在同一事务内插入 `event_type=wallet_credit` 审计（`dedup_key` 冲突则忽略），仅当新审计行真正落入时 `wallet_granted += amount`。
 

--- a/packages/core/src/lib/api-key-rate-limit.test.ts
+++ b/packages/core/src/lib/api-key-rate-limit.test.ts
@@ -1,11 +1,11 @@
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
 import {
+	API_KEY_RATE_WINDOW_MS,
 	coerceRateLimitInput,
 	consumeApiKeyRateWindow,
 	consumeRateLimitLayers,
 	createMemoryApiKeyRateLimitStore,
-	currentRateWindowStartedAt,
 	isRateLimitExceeded,
 	keyRateLimitSubject,
 	parseApiKeyRateLimit,
@@ -15,7 +15,25 @@ import {
 	resolveIngressHost,
 	serializeApiKeyRateLimit,
 	userRateLimitSubject,
+	type RateLimitLayer,
 } from './api-key-rate-limit.ts';
+
+const T0 = Date.parse('2026-09-05T02:31:42.123Z');
+const MINUTE_BOUNDARY_BEFORE = Date.parse('2026-09-05T02:31:59.500Z');
+const MINUTE_BOUNDARY_AFTER = Date.parse('2026-09-05T02:32:00.100Z');
+
+function layersFor(kind: 'key' | 'user', rpm: number | null): RateLimitLayer[] {
+	if (kind === 'key') {
+		return [
+			{ subject: keyRateLimitSubject('key-rolling'), rpm },
+			{ subject: userRateLimitSubject('user-unused'), rpm: null },
+		];
+	}
+	return [
+		{ subject: keyRateLimitSubject('key-unlimited'), rpm: null },
+		{ subject: userRateLimitSubject('user-rolling'), rpm },
+	];
+}
 
 describe('api-key-rate-limit', () => {
 	it('treats NULL rpm as unlimited', () => {
@@ -53,10 +71,10 @@ describe('api-key-rate-limit', () => {
 		assert.equal(isRateLimitExceeded(11, 10), true);
 	});
 
-	it('aligns window start to the minute', () => {
-		const t = Date.parse('2026-09-05T02:31:42.123Z');
-		assert.equal(currentRateWindowStartedAt(t), '2026-09-05T02:31:00.000Z');
-		assert.equal(rateLimitRetryAfterSeconds('2026-09-05T02:31:00.000Z', t), 18);
+	it('computes retry-after until the next consume can succeed', () => {
+		assert.equal(rateLimitRetryAfterSeconds([], 1, T0), 1);
+		assert.equal(rateLimitRetryAfterSeconds([T0], 0, T0), 60);
+		assert.equal(rateLimitRetryAfterSeconds([T0, T0 + 1_000], 1, T0 + 1_000), 60);
 	});
 
 	it('coerces PATCH rate_limit (omit / null / object)', () => {
@@ -78,29 +96,29 @@ describe('api-key-rate-limit', () => {
 		assert.equal(resolveIngressHost(null, 'not a url'), null);
 	});
 
-	it('counts in memory per key and resets when the window changes', async () => {
+	it('counts in memory per subject and drops timestamps outside the trailing 60s', async () => {
 		const store = createMemoryApiKeyRateLimitStore();
-		assert.equal(await consumeApiKeyRateWindow('k1', 'w1', store), 1);
-		assert.equal(await consumeApiKeyRateWindow('k1', 'w1', store), 2);
-		assert.equal(await consumeApiKeyRateWindow('k2', 'w1', store), 1);
-		assert.equal(await consumeApiKeyRateWindow('k1', 'w2', store), 1);
+		assert.equal((await consumeApiKeyRateWindow('k1', T0, 100, store)).count, 1);
+		assert.equal((await consumeApiKeyRateWindow('k1', T0 + 1, 100, store)).count, 2);
+		assert.equal((await consumeApiKeyRateWindow('k2', T0, 100, store)).count, 1);
+		assert.equal((await consumeApiKeyRateWindow('k1', T0 + 1 + API_KEY_RATE_WINDOW_MS, 100, store)).count, 1);
 	});
 
-	it('prunes stale windows when over capacity', async () => {
+	it('prunes stale subjects when over capacity', async () => {
 		const store = createMemoryApiKeyRateLimitStore(2);
-		assert.equal(await consumeApiKeyRateWindow('a', 'w1', store), 1);
-		assert.equal(await consumeApiKeyRateWindow('b', 'w1', store), 1);
-		assert.equal(await consumeApiKeyRateWindow('c', 'w2', store), 1);
-		assert.equal(await consumeApiKeyRateWindow('a', 'w2', store), 1);
+		assert.equal((await consumeApiKeyRateWindow('a', T0, 10, store)).count, 1);
+		assert.equal((await consumeApiKeyRateWindow('b', T0, 10, store)).count, 1);
+		assert.equal((await consumeApiKeyRateWindow('c', T0 + API_KEY_RATE_WINDOW_MS, 10, store)).count, 1);
+		assert.equal((await consumeApiKeyRateWindow('a', T0 + API_KEY_RATE_WINDOW_MS, 10, store)).count, 1);
 	});
 
 	it('does not consume the user window when the key layer is already exceeded', async () => {
 		const inner = createMemoryApiKeyRateLimitStore();
 		const subjects: string[] = [];
 		const store = {
-			consume(subject: string, windowStartedAt: string) {
+			consume(subject: string, nowMs: number, rpm: number) {
 				subjects.push(subject);
-				return inner.consume(subject, windowStartedAt);
+				return inner.consume(subject, nowMs, rpm);
 			},
 		};
 		const keyId = 'key-1';
@@ -109,8 +127,8 @@ describe('api-key-rate-limit', () => {
 			{ subject: keyRateLimitSubject(keyId), rpm: 1 },
 			{ subject: userRateLimitSubject(userId), rpm: 100 },
 		];
-		assert.equal((await consumeRateLimitLayers(layers, 'w1', store)).exceeded, false);
-		assert.equal((await consumeRateLimitLayers(layers, 'w1', store)).exceeded, true);
+		assert.equal((await consumeRateLimitLayers(layers, T0, store)).exceeded, false);
+		assert.equal((await consumeRateLimitLayers(layers, T0 + 1, store)).exceeded, true);
 		assert.deepEqual(subjects, [
 			keyRateLimitSubject(keyId),
 			userRateLimitSubject(userId),
@@ -126,7 +144,7 @@ describe('api-key-rate-limit', () => {
 				{ subject: keyRateLimitSubject('key-a'), rpm: null },
 				{ subject: userSubject, rpm: 2 },
 			],
-			'w1',
+			T0,
 			store
 		);
 		const second = await consumeRateLimitLayers(
@@ -134,7 +152,7 @@ describe('api-key-rate-limit', () => {
 				{ subject: keyRateLimitSubject('key-b'), rpm: null },
 				{ subject: userSubject, rpm: 2 },
 			],
-			'w1',
+			T0 + 1,
 			store
 		);
 		const third = await consumeRateLimitLayers(
@@ -142,11 +160,48 @@ describe('api-key-rate-limit', () => {
 				{ subject: keyRateLimitSubject('key-a'), rpm: null },
 				{ subject: userSubject, rpm: 2 },
 			],
-			'w1',
+			T0 + 2,
 			store
 		);
 		assert.equal(first.exceeded, false);
 		assert.equal(second.exceeded, false);
 		assert.equal(third.exceeded, true);
 	});
+
+	for (const kind of ['key', 'user'] as const) {
+		describe(`${kind} trailing 60s window`, () => {
+			it('exceeds on the rpm+1 request inside 60s', async () => {
+				const store = createMemoryApiKeyRateLimitStore();
+				const layers = layersFor(kind, 2);
+				assert.equal((await consumeRateLimitLayers(layers, T0, store)).exceeded, false);
+				assert.equal((await consumeRateLimitLayers(layers, T0 + 1, store)).exceeded, false);
+				assert.equal((await consumeRateLimitLayers(layers, T0 + 2, store)).exceeded, true);
+			});
+
+			it('allows the next request once the oldest timestamp is 60s old', async () => {
+				const store = createMemoryApiKeyRateLimitStore();
+				const layers = layersFor(kind, 1);
+				assert.equal((await consumeRateLimitLayers(layers, T0, store)).exceeded, false);
+				assert.equal((await consumeRateLimitLayers(layers, T0 + API_KEY_RATE_WINDOW_MS, store)).exceeded, false);
+			});
+
+			it('does not reset at the UTC minute boundary', async () => {
+				const store = createMemoryApiKeyRateLimitStore();
+				const layers = layersFor(kind, 1);
+				assert.equal((await consumeRateLimitLayers(layers, MINUTE_BOUNDARY_BEFORE, store)).exceeded, false);
+				assert.equal((await consumeRateLimitLayers(layers, MINUTE_BOUNDARY_AFTER, store)).exceeded, true);
+			});
+
+			it('returns retry-after until a new consume can succeed', async () => {
+				const store = createMemoryApiKeyRateLimitStore();
+				const layers = layersFor(kind, 1);
+				assert.equal((await consumeRateLimitLayers(layers, T0, store)).exceeded, false);
+				const exceeded = await consumeRateLimitLayers(layers, T0 + 1_000, store);
+				assert.equal(exceeded.exceeded, true);
+				assert.equal(exceeded.retryAfterSeconds, 60);
+				const retryAt = T0 + 1_000 + exceeded.retryAfterSeconds * 1000;
+				assert.equal((await consumeRateLimitLayers(layers, retryAt, store)).exceeded, false);
+			});
+		});
+	}
 });

--- a/packages/core/src/lib/api-key-rate-limit.ts
+++ b/packages/core/src/lib/api-key-rate-limit.ts
@@ -1,6 +1,6 @@
 /**
  * Per-key / per-user rate limit JSON (`api_keys.rate_limit`, `users.rate_limit`).
- * NULL / empty object = that layer is unlimited. Current dimension: `rpm` (rolling 60s).
+ * NULL / empty object = that layer is unlimited. Current dimension: `rpm` (trailing 60s from now).
  * `rpm: 0` rejects metered calls. Layers are independent; Key is a per-key cap, User is a shared pool.
  */
 
@@ -112,9 +112,11 @@ export function rateLimitRpmOf(limit: ApiKeyRateLimit | null | undefined): numbe
 	return limit?.rpm ?? null;
 }
 
-export function currentRateWindowStartedAt(nowMs = Date.now()): string {
-	const start = Math.floor(nowMs / API_KEY_RATE_WINDOW_MS) * API_KEY_RATE_WINDOW_MS;
-	return new Date(start).toISOString();
+function dropExpiredTimestamps(times: number[], nowMs: number): number[] {
+	const cutoff = nowMs - API_KEY_RATE_WINDOW_MS;
+	let i = 0;
+	while (i < times.length && times[i] <= cutoff) i += 1;
+	return i === 0 ? times : times.slice(i);
 }
 
 /** After incrementing the window, `count > rpm` is exceeded. NULL rpm is never exceeded. */
@@ -123,10 +125,20 @@ export function isRateLimitExceeded(count: number, rpm: number | null | undefine
 	return count > rpm;
 }
 
-export function rateLimitRetryAfterSeconds(windowStartedAtIso: string, nowMs = Date.now()): number {
-	const start = Date.parse(windowStartedAtIso);
-	if (!Number.isFinite(start)) return 60;
-	return Math.max(1, Math.ceil((start + API_KEY_RATE_WINDOW_MS - nowMs) / 1000));
+/**
+ * Seconds until a *new* consume on this subject can succeed.
+ * `times` is the stored trailing-60s log (oldest first), including the request just counted.
+ */
+export function rateLimitRetryAfterSeconds(times: number[], rpm: number, nowMs: number): number {
+	if (times.length === 0) return 1;
+	if (rpm <= 0) {
+		return Math.max(1, Math.ceil((times[0] + API_KEY_RATE_WINDOW_MS - nowMs) / 1000));
+	}
+	const numberToExpire = times.length - rpm + 1;
+	if (numberToExpire <= 0) return 1;
+	const t = times[numberToExpire - 1];
+	if (t == null) return 1;
+	return Math.max(1, Math.ceil((t + API_KEY_RATE_WINDOW_MS - nowMs) / 1000));
 }
 
 export function keyRateLimitSubject(keyId: string): string {
@@ -142,13 +154,18 @@ export type RateLimitLayer = {
 	rpm: number | null | undefined;
 };
 
+export type RateLimitConsumeResult = {
+	count: number;
+	retryAfterSeconds: number;
+};
+
 /**
- * Per-subject RPM window counter. Default is process/isolate memory (same consistency as
+ * Per-subject trailing-60s RPM log. Default is process/isolate memory (same consistency as
  * circuit breakers). Swap in Redis later via `setApiKeyRateLimitStore`.
  * Subjects should be prefixed (`k:` / `u:`) so key and user UUIDs never collide.
  */
 export type ApiKeyRateLimitStore = {
-	consume(subject: string, windowStartedAt: string): number | Promise<number>;
+	consume(subject: string, nowMs: number, rpm: number): RateLimitConsumeResult | Promise<RateLimitConsumeResult>;
 };
 
 const MEMORY_RATE_LIMIT_MAX_ENTRIES = 50_000;
@@ -156,30 +173,35 @@ const MEMORY_RATE_LIMIT_MAX_ENTRIES = 50_000;
 export function createMemoryApiKeyRateLimitStore(
 	maxEntries = MEMORY_RATE_LIMIT_MAX_ENTRIES
 ): ApiKeyRateLimitStore {
-	const windows = new Map<string, { windowStartedAt: string; count: number }>();
+	const windows = new Map<string, number[]>();
 	return {
-		consume(subject, windowStartedAt) {
-			const prev = windows.get(subject);
-			if (!prev || prev.windowStartedAt !== windowStartedAt) {
-				windows.set(subject, { windowStartedAt, count: 1 });
-			} else {
-				prev.count += 1;
-			}
+		consume(subject, nowMs, rpm) {
+			const times = dropExpiredTimestamps(windows.get(subject) ?? [], nowMs);
+			const keepLimit = rpm + 1;
+			if (times.length < keepLimit) times.push(nowMs);
+			if (times.length === 0) windows.delete(subject);
+			else windows.set(subject, times);
 			if (windows.size > maxEntries) {
 				for (const [id, row] of windows) {
-					if (row.windowStartedAt !== windowStartedAt) windows.delete(id);
+					const pruned = dropExpiredTimestamps(row, nowMs);
+					if (pruned.length === 0) windows.delete(id);
+					else windows.set(id, pruned);
 				}
 				if (windows.size > maxEntries) {
 					const overflow = windows.size - maxEntries;
 					let dropped = 0;
 					for (const id of windows.keys()) {
 						if (dropped >= overflow) break;
+						if (id === subject) continue;
 						windows.delete(id);
 						dropped += 1;
 					}
 				}
 			}
-			return windows.get(subject)?.count ?? 1;
+			return {
+				count: times.length,
+				retryAfterSeconds: rateLimitRetryAfterSeconds(times, rpm, nowMs),
+			};
 		},
 	};
 }
@@ -196,27 +218,29 @@ export function setApiKeyRateLimitStore(store: ApiKeyRateLimitStore): void {
 
 export async function consumeApiKeyRateWindow(
 	subject: string,
-	windowStartedAt: string,
+	nowMs: number,
+	rpm: number,
 	store: ApiKeyRateLimitStore = getApiKeyRateLimitStore()
-): Promise<number> {
-	return store.consume(subject, windowStartedAt);
+): Promise<RateLimitConsumeResult> {
+	return store.consume(subject, nowMs, rpm);
 }
 
 /**
  * Consume layers in order (typically Key then User). A layer with NULL rpm is skipped.
  * If a layer is already exceeded, later layers are not consumed.
+ * `retryAfterSeconds` is from the layer that exceeded (1 when none did).
  */
 export async function consumeRateLimitLayers(
 	layers: RateLimitLayer[],
-	windowStartedAt: string,
+	nowMs = Date.now(),
 	store: ApiKeyRateLimitStore = getApiKeyRateLimitStore()
-): Promise<{ exceeded: boolean }> {
+): Promise<{ exceeded: boolean; retryAfterSeconds: number }> {
 	for (const layer of layers) {
 		if (layer.rpm == null) continue;
-		const count = await consumeApiKeyRateWindow(layer.subject, windowStartedAt, store);
-		if (isRateLimitExceeded(count, layer.rpm)) {
-			return { exceeded: true };
+		const consumed = await consumeApiKeyRateWindow(layer.subject, nowMs, layer.rpm, store);
+		if (isRateLimitExceeded(consumed.count, layer.rpm)) {
+			return { exceeded: true, retryAfterSeconds: consumed.retryAfterSeconds };
 		}
 	}
-	return { exceeded: false };
+	return { exceeded: false, retryAfterSeconds: 1 };
 }

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -20,7 +20,7 @@ export type ApiKeyBudgetAuditActorType = 'system' | 'admin' | 'service';
 
 /** `api_keys.rate_limit` / `users.rate_limit` JSON。NULL / 空对象 = 该层不限；后续可加 `rpd` 等维度。 */
 export type ApiKeyRateLimit = {
-	/** 每 60 秒滚动窗口请求数。`0` 拒绝计次请求；省略表示该维度不限。 */
+	/** 从当前时刻回溯 60 秒的滚动窗口请求数。`0` 拒绝计次请求；省略表示该维度不限。 */
 	rpm?: number;
 };
 

--- a/packages/proxy/src/middleware/auth.ts
+++ b/packages/proxy/src/middleware/auth.ts
@@ -11,10 +11,8 @@ import type { ApiKeyRateLimit } from '@octafuse/core';
 import { parseDashScopeRealtimeAuthProtocol } from '@octafuse/core/realtime-protocol';
 import {
 	consumeRateLimitLayers,
-	currentRateWindowStartedAt,
 	hasPositiveTotalBalance,
 	keyRateLimitSubject,
-	rateLimitRetryAfterSeconds,
 	rateLimitRpmOf,
 	resolveIngressHost,
 	userRateLimitSubject,
@@ -128,21 +126,16 @@ export const requireApiKey = createMiddleware<Env>(async (c, next) => {
   // Allow GET /v1/me even when budget is 0 or rate-limited, so clients can show key / budget state
   const isKeyInfoRoute = c.req.method === 'GET' && c.req.path.endsWith('/me');
   if (!isKeyInfoRoute) {
-    const windowStartedAt = currentRateWindowStartedAt();
-    const { exceeded } = await consumeRateLimitLayers(
-      [
-        { subject: keyRateLimitSubject(authResult.keyId), rpm: rateLimitRpmOf(authResult.rateLimit) },
-        { subject: userRateLimitSubject(authResult.userId), rpm: rateLimitRpmOf(authResult.userRateLimit) },
-      ],
-      windowStartedAt
-    );
+    const { exceeded, retryAfterSeconds } = await consumeRateLimitLayers([
+      { subject: keyRateLimitSubject(authResult.keyId), rpm: rateLimitRpmOf(authResult.rateLimit) },
+      { subject: userRateLimitSubject(authResult.userId), rpm: rateLimitRpmOf(authResult.userRateLimit) },
+    ]);
     if (exceeded) {
-      const retryAfter = String(rateLimitRetryAfterSeconds(windowStartedAt));
       return gatewayErrorJson(c, {
         status: 429,
         code: GatewayErrorCode.rateLimited,
         message: 'Rate limit exceeded',
-        headers: { 'Retry-After': retryAfter },
+        headers: { 'Retry-After': String(retryAfterSeconds) },
       });
     }
   }


### PR DESCRIPTION
…d keys

- Clarified the rate limit behavior in the API documentation, specifying that the limits are based on a rolling 60-second window from the current time, rather than UTC natural minutes.
- Enhanced the implementation of rate limiting for both users and API keys to ensure independent counting and enforcement of limits.
- Updated related tests to validate the new rate limit logic and ensure accurate behavior under various scenarios.
- Adjusted the API key rate limit handling to include retry-after logic for better user feedback when limits are exceeded.

## Summary

<!-- What does this PR change and why? -->

## Target branch

<!-- Normal features/contributions target develop. Releases use release/X.Y.Z when a freeze branch is needed; current-release hotfixes use hotfix/X.Y.Z and target main. -->

- [ ] This PR targets `develop`, or a maintainer has confirmed `main` / another base branch for a release or hotfix.

## Type of change

<!-- Check all that apply -->

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change (describe migration / release notes impact)
- [ ] Documentation only
- [ ] Build / CI / chore

## Checklist

- [ ] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) (including the contribution license terms).
- [ ] For user-visible behavior or API changes, I updated docs where appropriate.
- [ ] I added a changeset for user-visible changes, or documented why it is deferred / unnecessary.
- [ ] I ran relevant tests or smoke scripts locally when applicable (e.g. `npm run test:gateway:postgres-smoke`).

## Related issues

<!-- Link e.g. Fixes #123 -->
