### PR TITLE
fix(rate-limit): enforce integer validation for RPM values

### DIFF
--- a/packages/admin/app/gateway/keys/page.tsx
+++ b/packages/admin/app/gateway/keys/page.tsx
@@ -289,7 +289,7 @@ export default function GatewayKeysPage() {
 
       const rpmRaw = editFormData.rateLimitRpm.trim();
       const rpmParsed = rpmRaw === '' ? null : Number(rpmRaw);
-      if (rpmRaw !== '' && (rpmParsed == null || !Number.isFinite(rpmParsed) || rpmParsed < 0)) {
+      if (rpmRaw !== '' && (rpmParsed == null || !Number.isFinite(rpmParsed) || rpmParsed < 0 || !Number.isInteger(rpmParsed))) {
         setSaveError(t('help.rateLimitRpmInvalid'));
         setIsSaving(false);
         return;

--- a/packages/core/src/lib/api-key-rate-limit.test.ts
+++ b/packages/core/src/lib/api-key-rate-limit.test.ts
@@ -48,6 +48,7 @@ describe('api-key-rate-limit', () => {
 		assert.deepEqual(parseApiKeyRateLimit({ rpm: 0 }), { rpm: 0 });
 		assert.equal(parseApiKeyRateLimit('not-json'), null);
 		assert.equal(parseApiKeyRateLimit({ rpm: -1 }), null);
+		assert.equal(parseApiKeyRateLimit({ rpm: 1.5 }), null);
 		assert.deepEqual(parseApiKeyRateLimit({ rpm: 60, rpd: 10 }), { rpm: 60 });
 	});
 
@@ -84,7 +85,10 @@ describe('api-key-rate-limit', () => {
 		assert.deepEqual(coerceRateLimitInput({}), { ok: true, value: null });
 		assert.deepEqual(coerceRateLimitInput({ rpm: 60 }), { ok: true, value: { rpm: 60 } });
 		assert.deepEqual(coerceRateLimitInput('{"rpm":60}'), { ok: true, value: { rpm: 60 } });
+		assert.deepEqual(coerceRateLimitInput({ rpm: '60' }), { ok: true, value: { rpm: 60 } });
 		assert.equal(coerceRateLimitInput({ rpm: -1 }).ok, false);
+		assert.equal(coerceRateLimitInput({ rpm: 1.5 }).ok, false);
+		assert.equal(coerceRateLimitInput({ rpm: '1.5' }).ok, false);
 		assert.equal(coerceRateLimitInput({ rpd: 10 }).ok, false);
 		assert.equal(coerceRateLimitInput(60).ok, false);
 	});

--- a/packages/core/src/lib/api-key-rate-limit.ts
+++ b/packages/core/src/lib/api-key-rate-limit.ts
@@ -30,8 +30,8 @@ function parseNonNegativeInt(raw: unknown): number | null {
 	if (raw == null || raw === '') return null;
 	if (typeof raw === 'boolean' || typeof raw === 'object') return null;
 	const n = typeof raw === 'number' ? raw : Number(raw);
-	if (!Number.isFinite(n) || n < 0) return null;
-	return Math.floor(n);
+	if (!Number.isFinite(n) || n < 0 || !Number.isInteger(n)) return null;
+	return n;
 }
 
 function extractKnownRateLimit(raw: Record<string, unknown>): ApiKeyRateLimit | null {

--- a/packages/proxy/src/services/accounting/types.ts
+++ b/packages/proxy/src/services/accounting/types.ts
@@ -26,7 +26,7 @@ export type RecordUsageParams = {
 	provider_name?: string | null;
 	request_body?: string | null;
 	upstream_request_body?: string | null;
-	request_protocol: 'openai' | 'anthropic' | 'gemini';
+	request_protocol: UpstreamProtocol;
 	request_operation?: string | null;
 	upstream_protocol: UpstreamProtocol;
 	upstream_operation?: string | null;

--- a/packages/proxy/src/services/user-model-circuit-route.ts
+++ b/packages/proxy/src/services/user-model-circuit-route.ts
@@ -2,7 +2,7 @@
  * v1 代理路由共用的 user+model 熔断：请求前短路 + 上游触发写入 + 成功清零 + 短路请求记账。
  */
 import type { Context } from 'hono';
-import type { GatewayRepositories } from '@octafuse/core';
+import type { GatewayRepositories, UpstreamProtocol } from '@octafuse/core';
 import type { ApiKeyContext } from '../middleware/auth';
 import { scheduleBackgroundWork } from '../runtime/schedule-background-work';
 import { EMPTY_USAGE } from './proxy';
@@ -25,7 +25,7 @@ export type UserModelCircuitRouteContext = {
 	baseModelId: string;
 	modelNameForLog: string;
 	requestBodyForLog: string | null;
-	requestProtocol: 'openai' | 'anthropic' | 'gemini';
+	requestProtocol: UpstreamProtocol;
 	startMs: number;
 	timing?: RequestTimingCollector | null;
 	/**


### PR DESCRIPTION
- Updated the rate limit validation logic to ensure that RPM values are non-negative integers, preventing invalid inputs.
- Enhanced the `parseNonNegativeInt` function to reject non-integer values, including decimals.
- Added corresponding test cases to validate the new integer enforcement for RPM inputs in the rate limit parsing and coercion functions.

## Summary

<!-- What does this PR change and why? -->

## Target branch

<!-- Normal features/contributions target develop. Releases use release/X.Y.Z when a freeze branch is needed; current-release hotfixes use hotfix/X.Y.Z and target main. -->

- [ ] This PR targets `develop`, or a maintainer has confirmed `main` / another base branch for a release or hotfix.

## Type of change

<!-- Check all that apply -->

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change (describe migration / release notes impact)
- [ ] Documentation only
- [ ] Build / CI / chore

## Checklist

- [ ] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) (including the contribution license terms).
- [ ] For user-visible behavior or API changes, I updated docs where appropriate.
- [ ] I added a changeset for user-visible changes, or documented why it is deferred / unnecessary.
- [ ] I ran relevant tests or smoke scripts locally when applicable (e.g. `npm run test:gateway:postgres-smoke`).

## Related issues

<!-- Link e.g. Fixes #123 -->
