### PR TITLE
fix(proxy): inject sequence_number for Responses SSE events missing it

### DIFF
--- a/.changeset/responses-sequence-number-fallbacks.md
+++ b/.changeset/responses-sequence-number-fallbacks.md
@@ -1,0 +1,10 @@
+---
+"@octafuse/proxy": patch
+"octafuse": patch
+---
+
+为缺失 `sequence_number` 的 OpenAI Responses SSE 事件兜底注入递增序号。
+
+### Proxy
+
+- **Responses 序号兜底**：部分上游（如 DeepSeek / GLM 聚合层）返回的 Responses 流式事件不含 `sequence_number`，Grok CLI 等严格反序列化客户端会因 `missing field sequence_number` 中断。`openai-responses-driver` 在转发每个 `data:` 事件前调用 `ensureResponsesSequenceNumber`：仅当事件顶层缺失该字段时注入递增序号；上游已带序号的事件原样保留，并让计数器越过该值避免后续注入重复。

--- a/docs/developers/api/user.md
+++ b/docs/developers/api/user.md
@@ -197,7 +197,7 @@ curl http://localhost:8787/v1/chat/completions \
 
 ## Responses
 
-OpenAI Responses 兼容入口，支持非流式 JSON 与 `stream=true` 的 typed SSE。上游必须配置 `openai.responses` 请求入口，并使用同协议 `passthrough`。
+OpenAI Responses 兼容入口，支持非流式 JSON 与 `stream=true` 的 typed SSE。上游必须配置 `openai.responses` 请求入口，并使用同协议 `passthrough`。流式 `data:` 事件若缺少顶层 `sequence_number`，网关会按本次连接注入递增整数（从 0 起）；上游已带该字段的事件原样转发。
 
 ### 请求
 

--- a/packages/proxy/src/services/egress/openai-responses-driver.test.ts
+++ b/packages/proxy/src/services/egress/openai-responses-driver.test.ts
@@ -2,8 +2,10 @@ import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
 import {
 	applyResponsesUsage,
+	ensureResponsesSequenceNumber,
 	isResponsesTerminalEventType,
 	processResponsesDataLine,
+	syntheticMissingTerminalEvent,
 	usageFromResponses,
 } from './openai-responses-driver';
 import type { UsageFromStream } from '../proxy';
@@ -102,5 +104,74 @@ describe('openai-responses-driver SSE lines', () => {
 		assert.equal(usage.input_tokens, 9);
 		assert.equal(usage.output_tokens, 4);
 		assert.equal(usage.total_tokens, 13);
+	});
+});
+
+describe('ensureResponsesSequenceNumber', () => {
+	it('injects an incrementing sequence_number when the event is missing it', () => {
+		const seq = { value: 0 };
+		const a = ensureResponsesSequenceNumber(
+			`data: ${JSON.stringify({ type: 'response.created' })}`,
+			seq,
+		);
+		const b = ensureResponsesSequenceNumber(
+			`data: ${JSON.stringify({ type: 'response.output_text.delta', delta: 'hi' })}`,
+			seq,
+		);
+		assert.equal(JSON.parse(a.slice(6)).sequence_number, 0);
+		assert.equal(JSON.parse(b.slice(6)).sequence_number, 1);
+		assert.equal(seq.value, 2);
+	});
+
+	it('starts from 0 and preserves upstream sequence numbers without overwriting', () => {
+		const seq = { value: 0 };
+		// 上游已带 sequence_number=7，应原样保留且计数器越过去。
+		const out = ensureResponsesSequenceNumber(
+			`data: ${JSON.stringify({ type: 'response.output_text.done', sequence_number: 7 })}`,
+			seq,
+		);
+		assert.equal(out, `data: ${JSON.stringify({ type: 'response.output_text.done', sequence_number: 7 })}`);
+		assert.equal(JSON.parse(out.slice(6)).sequence_number, 7);
+		assert.equal(seq.value, 8);
+
+		// 下一个缺失事件应接着 8 注入，避免与上游重复。
+		const next = ensureResponsesSequenceNumber(`data: {"type":"response.completed"}`, seq);
+		assert.equal(JSON.parse(next.slice(6)).sequence_number, 8);
+	});
+
+	it('leaves non-data lines, [DONE], and non-object JSON untouched', () => {
+		const seq = { value: 0 };
+		assert.equal(ensureResponsesSequenceNumber('event: response.created', seq), 'event: response.created');
+		assert.equal(ensureResponsesSequenceNumber('data: [DONE]', seq), 'data: [DONE]');
+		assert.equal(ensureResponsesSequenceNumber('data: "just a string"', seq), 'data: "just a string"');
+		assert.equal(ensureResponsesSequenceNumber('data: [1,2]', seq), 'data: [1,2]');
+		assert.equal(seq.value, 0);
+	});
+
+	it('keeps the data: prefix and round-trips unknown fields', () => {
+		const seq = { value: 0 };
+		const input = `data: ${JSON.stringify({ type: 'response.output_text.delta', delta: 'OK', item_id: 'i_1' })}`;
+		const out = ensureResponsesSequenceNumber(input, seq);
+		const parsed = JSON.parse(out.slice(6));
+		assert.equal(parsed.type, 'response.output_text.delta');
+		assert.equal(parsed.delta, 'OK');
+		assert.equal(parsed.item_id, 'i_1');
+		assert.equal(parsed.sequence_number, 0);
+	});
+
+	it('synthetic terminal error event carries a sequence_number', () => {
+		// 场景：上游已发 3 个事件（0/1/2），随后静默 EOF，网关补发 error 事件。
+		const seq = { value: 0 };
+		ensureResponsesSequenceNumber(`data: {"type":"response.created"}`, seq);
+		ensureResponsesSequenceNumber(`data: {"type":"response.in_progress"}`, seq);
+		ensureResponsesSequenceNumber(`data: {"type":"response.output_item.added"}`, seq);
+		assert.equal(seq.value, 3);
+		const out = syntheticMissingTerminalEvent(seq);
+		const dataLine = out.split('\n').find((l) => l.startsWith('data: '));
+		assert.ok(dataLine, 'synthetic event contains a data: line');
+		const parsed = JSON.parse(dataLine!.slice(6));
+		assert.equal(parsed.type, 'error');
+		assert.equal(parsed.sequence_number, 3);
+		assert.equal(seq.value, 4);
 	});
 });

--- a/packages/proxy/src/services/egress/openai-responses-driver.ts
+++ b/packages/proxy/src/services/egress/openai-responses-driver.ts
@@ -9,7 +9,8 @@ import type { RequestTimingAttempt, RequestTimingCollector } from '../request-ti
  * OpenAI Responses API 透传：
  * - 非流式 JSON 从终态 `usage` 记账
  * - SSE 识别 typed events，usage 通常在 `response.completed` / `response.incomplete`
- * - 原样转发事件；上游静默 EOF 时补一条 `error`，避免客户端挂死
+ * - 转发事件；缺失顶层 `sequence_number` 时按连接注入递增序号，已有序号原样保留
+ * - 上游静默 EOF 时补一条带序号的 `error`，避免客户端挂死
  */
 
 const EMPTY_USAGE_LOCAL: UsageFromStream = {

--- a/packages/proxy/src/services/egress/openai-responses-driver.ts
+++ b/packages/proxy/src/services/egress/openai-responses-driver.ts
@@ -66,6 +66,8 @@ type ResponsesUsage = {
 type ResponsesEvent = {
 	type?: string;
 	id?: string;
+	/** OpenAI Responses 流式事件顶层必填序号；缺失时由网关兜底注入，见 `ensureResponsesSequenceNumber`。 */
+	sequence_number?: number;
 	delta?: unknown;
 	usage?: ResponsesUsage;
 	response?: {
@@ -75,6 +77,45 @@ type ResponsesEvent = {
 	};
 	error?: { message?: string; code?: string };
 };
+
+/**
+ * 为缺失 `sequence_number` 的 Responses SSE `data:` 行注入递增序号。
+ *
+ * OpenAI Responses 协议要求每个 typed event 顶层都带 `sequence_number`（整数序号）。
+ * 部分上游（如 DeepSeek / GLM 聚合层）返回的事件不含该字段，Grok CLI 等严格 serde
+ * 客户端在反序列化时会因 `missing field sequence_number` 而中断。
+ *
+ * 本函数仅在事件顶层缺失 `sequence_number` 时补一个递增整数；上游已带序号的事件
+ * 原样保留，并让内部计数器至少跟进到该值，避免后续注入序号与上游重复。
+ *
+ * - `data: [DONE]`、非 JSON 行、`event:` 行原样返回（不注入）。
+ * - 返回注入后的整行（含 `data: ` 前缀与换行由调用方处理）。
+ */
+export function ensureResponsesSequenceNumber(
+	line: string,
+	nextSeq: { value: number },
+): string {
+	if (!line.startsWith('data: ')) return line;
+	const payload = line.slice(6).trim();
+	if (!payload || payload === '[DONE]') return line;
+	try {
+		const parsed = JSON.parse(payload) as unknown;
+		if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return line;
+		const event = parsed as ResponsesEvent;
+		if (typeof event.sequence_number === 'number') {
+			// 上游已带序号：不覆盖，但让计数器至少越过该值，避免后续注入重复。
+			if (event.sequence_number >= nextSeq.value) {
+				nextSeq.value = event.sequence_number + 1;
+			}
+			return line;
+		}
+		const injected = { ...event, sequence_number: nextSeq.value };
+		nextSeq.value += 1;
+		return `data: ${JSON.stringify(injected)}`;
+	} catch {
+		return line;
+	}
+}
 
 type SSEState = { lineBuffer: string };
 
@@ -168,11 +209,14 @@ export function processResponsesDataLine(
 	}
 }
 
-function syntheticMissingTerminalEvent(): string {
+/** 上游静默 EOF 时的兜底 error 事件；必须带 `sequence_number`（严格 serde 客户端必填）。 */
+export function syntheticMissingTerminalEvent(nextSeq: { value: number }): string {
 	return (
 		'event: error\n' +
 		`data: ${JSON.stringify({
 			type: 'error',
+			// 合成事件同样必须带序号；缺失会让严格客户端（serde）在兜底错误上报序列化失败。
+			sequence_number: nextSeq.value++,
 			error: {
 				message: 'Upstream stream ended without a terminal Responses event',
 				code: 'responses.incomplete_stream',
@@ -192,6 +236,8 @@ async function pumpResponsesWithUsageTracking(
 	const reader = upstream.getReader();
 	const writer = downstream.getWriter();
 	const state: SSEState = { lineBuffer: '' };
+	// 缺失 sequence_number 时的兜底注入计数器（从 0 递增，见 ensureResponsesSequenceNumber）。
+	const nextSeq = { value: 0 };
 	let clientDisconnected = false;
 	let disconnectTime = 0;
 	let sawTerminal = false;
@@ -226,12 +272,12 @@ async function pumpResponsesWithUsageTracking(
 					const line = state.lineBuffer.trim();
 					state.lineBuffer = '';
 					if (processResponsesDataLine(line, usage, timing)) sawTerminal = true;
-					await writeChunk(line + '\n');
+					await writeChunk(ensureResponsesSequenceNumber(line, nextSeq) + '\n');
 				}
 				if (!sawTerminal && !clientDisconnected) {
 					usage.stream_error =
 						usage.stream_error ?? 'Upstream stream ended without a terminal Responses event';
-					await writeChunk(syntheticMissingTerminalEvent());
+					await writeChunk(syntheticMissingTerminalEvent(nextSeq));
 				}
 				break;
 			}
@@ -244,7 +290,7 @@ async function pumpResponsesWithUsageTracking(
 			let forward = '';
 			for (const line of lines) {
 				if (processResponsesDataLine(line, usage, timing)) sawTerminal = true;
-				forward += line + '\n';
+				forward += ensureResponsesSequenceNumber(line, nextSeq) + '\n';
 			}
 			await writeChunk(forward);
 
@@ -263,7 +309,7 @@ async function pumpResponsesWithUsageTracking(
 		if (!sawTerminal && !clientDisconnected) {
 			usage.stream_error = usage.stream_error ?? (err instanceof Error ? err.message : String(err));
 			try {
-				await writeChunk(syntheticMissingTerminalEvent());
+				await writeChunk(syntheticMissingTerminalEvent(nextSeq));
 			} catch {
 				// already disconnected
 			}


### PR DESCRIPTION
## Summary

Some upstream providers (observed with DeepSeek / GLM aggregator layers) return OpenAI Responses SSE events **without the required top-level `sequence_number` field**. Strict deserializing clients such as Grok CLI abort the whole turn with:

```
Couldn't read the response: serialization error: missing field `sequence_number`. Try sending again
```

The gateway currently forwards Responses SSE events byte-for-byte (passthrough by design), so an upstream that omits `sequence_number` makes `/v1/responses` unusable for strict clients even though the gateway itself works.

This PR adds a minimal fallback in the Responses SSE pump:

- New `ensureResponsesSequenceNumber(line, nextSeq)` pure function: when a `data:` event is missing top-level `sequence_number`, inject an incrementing integer (starting from 0, per connection).
- Events that already carry `sequence_number` are forwarded **untouched**; the internal counter only steps past the upstream value so injected numbers never collide with upstream ones.
- `data: [DONE]`, `event:` lines, non-object JSON (strings / arrays), and unparseable lines are passed through unchanged.
- The synthetic terminal `error` event (emitted when upstream ends the stream without a terminal event) also carried no `sequence_number` — it would fail the same strict clients at the exact moment it tries to report the failure — so it now consumes the next counter value too.

Verified against a live affected upstream: a real 39-event stream with 0% `sequence_number` coverage comes out with 100% coverage and strictly increasing numbers (0→38). The compliant case (upstream already sends `sequence_number`) is covered by unit tests and remains byte-identical.

## Target branch

- [x] This PR targets `develop`, or a maintainer has confirmed `main` / another base branch for a release or hotfix.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change (describe migration / release notes impact)
- [ ] Documentation only
- [ ] Build / CI / chore

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) (including the contribution license terms).
- [ ] For user-visible behavior or API changes, I updated docs where appropriate. *(deferred — see note below)*
- [x] I added a changeset for user-visible changes, or documented why it is deferred / unnecessary.
- [x] I ran relevant tests or smoke scripts locally when applicable.

## Related issues

None open — searched the tracker for `sequence_number` / `serialization` / `responses SSE` (only #87, which was the original "support Responses API" request, already shipped in 2.5.0).
