### PR TITLE
feat(admin): add DeepSeek V4.1 Flash preset and reprice the Flash line

### DIFF
--- a/.changeset/deepseek-v4.1-flash-pricing.md
+++ b/.changeset/deepseek-v4.1-flash-pricing.md
@@ -1,0 +1,8 @@
+---
+"@octafuse/admin": patch
+---
+
+新增 DeepSeek V4.1 Flash 预设，并把 Flash 系列目录价更新为 2026-09-10 起施行的空闲时段价。
+
+### Admin
+- **DeepSeek Flash 调价**：`deepseek-v4-flash` 与新增的 `deepseek-v4.1-flash` 统一使用新的空闲时段价（输入缓存命中 ¥0.02 / $0.003、缓存未命中 ¥1 / $0.15、输出 ¥4 / $0.6），工作日 09:00–12:00、14:00–18:00 的高峰倍率维持 2。

--- a/packages/admin/lib/model-preset.ts
+++ b/packages/admin/lib/model-preset.ts
@@ -14,7 +14,7 @@
  * 各预设内 **`pricing.usd`** 与 D1 导出 `data/remote/.../data-remote-table-models-*.sql` 中 `pricing_profile` 一致（美元口径）；
  * **`pricing.cny`**：国内厂商以中国区官方/Postgres 价为准；海外厂商（openai / anthropic / google / xai 等）按 **USD × 7** 换算占位。
  * 导入时按当前 `BILLING_CURRENCY` 选用 `usd` / `cny` **整段**写入 `pricing_profile`（含可选 `schedule` 官方时段，不只 `tiers`）。
- * DeepSeek V4 目录价为空闲价；`schedule` 为北京时间工作日高峰 09:00–12:00、14:00–18:00、`factor` 2。命中按 `BUSINESS_TIMEZONE` 墙钟，中国区请设 `Asia/Shanghai`。
+ * DeepSeek V4 / V4.1 目录价为空闲价；`schedule` 为北京时间工作日高峰 09:00–12:00、14:00–18:00、`factor` 2。命中按 `BUSINESS_TIMEZONE` 墙钟，中国区请设 `Asia/Shanghai`。
  * Google Gemini 目录价为 Standard 标准价，不含限时导入价、Batch、Flex。Flash 3.7 / 3.8 写入 $1.50 / $7.50，而不是 2026-12-31 前的 $0.75 / $3.75。
  * 面向 Catalog 的英文摘要与中英文展示文案均与模型预设共同维护：
  * `description` 写入现有 `models.description`，`i18n` 仅供静态 Catalog 展示，不增加数据库字段。

--- a/packages/admin/lib/model-presets/deepseek.json
+++ b/packages/admin/lib/model-presets/deepseek.json
@@ -1,5 +1,78 @@
 [
 	{
+		"id": "deepseek-v4.1-flash",
+		"display_name": "DeepSeek V4.1 Flash",
+		"description": "The official DeepSeek V4.1 Flash model for fast long-context reasoning, coding, and agents. In internal and external evaluations, it comprehensively surpasses V4 Pro in performance, cost, speed, and total time.",
+		"i18n": {
+			"en": "The official DeepSeek V4.1 Flash model for fast long-context reasoning, coding, and agents. In internal and external evaluations, it comprehensively surpasses V4 Pro in performance, cost, speed, and total time.",
+			"zh": "DeepSeek V4.1 Flash 正式版，面向高速长上下文推理、编程与 Agent。经内部、外部多方测试，在性能、费用、速度、总用时等各项指标上已全面超越 V4 Pro。"
+		},
+		"vendor": "deepseek",
+		"context_window": 1000000,
+		"max_tokens": 384000,
+		"pricing": {
+			"usd": {
+				"tiers": [
+					{
+						"upto": null,
+						"input_price": 0.15,
+						"output_price": 0.6,
+						"cache_read_price": 0.003,
+						"cache_write_price": null
+					}
+				],
+				"schedule": [
+					{
+						"start": "09:00",
+						"end": "12:00",
+						"factor": 2,
+						"days": [1, 2, 3, 4, 5]
+					},
+					{
+						"start": "14:00",
+						"end": "18:00",
+						"factor": 2,
+						"days": [1, 2, 3, 4, 5]
+					}
+				]
+			},
+			"cny": {
+				"tiers": [
+					{
+						"upto": null,
+						"input_price": 1,
+						"output_price": 4,
+						"cache_read_price": 0.02,
+						"cache_write_price": null
+					}
+				],
+				"schedule": [
+					{
+						"start": "09:00",
+						"end": "12:00",
+						"factor": 2,
+						"days": [1, 2, 3, 4, 5]
+					},
+					{
+						"start": "14:00",
+						"end": "18:00",
+						"factor": 2,
+						"days": [1, 2, 3, 4, 5]
+					}
+				]
+			}
+		},
+		"modalities": {
+			"input": [
+				"text"
+			],
+			"output": [
+				"text"
+			]
+		},
+		"released": "2026-09-10"
+	},
+	{
 		"id": "deepseek-v4-pro",
 		"display_name": "DeepSeek V4 Pro",
 		"description": "The official DeepSeek V4 Pro flagship for advanced reasoning, coding, and sustained agent workloads. The 0813 production checkpoint keeps 1M context and dual thinking modes under the same API name.",
@@ -88,9 +161,9 @@
 				"tiers": [
 					{
 						"upto": null,
-						"input_price": 0.22,
-						"output_price": 0.66,
-						"cache_read_price": 0.007,
+						"input_price": 0.15,
+						"output_price": 0.6,
+						"cache_read_price": 0.003,
 						"cache_write_price": null
 					}
 				],
@@ -113,9 +186,9 @@
 				"tiers": [
 					{
 						"upto": null,
-						"input_price": 1.5,
-						"output_price": 4.5,
-						"cache_read_price": 0.05,
+						"input_price": 1,
+						"output_price": 4,
+						"cache_read_price": 0.02,
 						"cache_write_price": null
 					}
 				],

--- a/packages/admin/lib/services/admin/import-catalog-billing.test.ts
+++ b/packages/admin/lib/services/admin/import-catalog-billing.test.ts
@@ -118,6 +118,22 @@ describe('import catalog pricing preview follows billing currency', () => {
 		assert.equal(profile?.tiers[1]?.input_price, 20);
 		assert.equal(profile?.tiers[1]?.output_price, 75);
 	});
+
+	it('includes deepseek-v4.1-flash and re-prices the Flash line at the 2026-09-10 off-peak list prices', () => {
+		const v41 = listStaticModelPresetCatalogForAdmin('USD').find((r) => r.id === 'deepseek-v4.1-flash');
+		assert.ok(v41);
+		assert.equal(v41!.display_name, 'DeepSeek V4.1 Flash');
+		assert.equal(v41!.context_window, 1000000);
+		assert.equal(v41!.max_tokens, 384000);
+		for (const id of ['deepseek-v4-flash', 'deepseek-v4.1-flash']) {
+			const usd = listStaticModelPresetCatalogForAdmin('USD').find((r) => r.id === id);
+			const cny = listStaticModelPresetCatalogForAdmin('CNY').find((r) => r.id === id);
+			assert.ok(usd, id);
+			assert.ok(cny, id);
+			assert.equal(usd!.pricing_label, '$0.15 / $0.6 /M', `${id} USD`);
+			assert.equal(cny!.pricing_label, '¥1 / ¥4 /M', `${id} CNY`);
+		}
+	});
 });
 
 describe('import catalog localized model metadata', () => {
@@ -151,7 +167,7 @@ const DEEPSEEK_V4_PEAK_SCHEDULE = [
 
 describe('static preset import writes catalog schedule', () => {
 	it('keeps DeepSeek V4 official peak windows on both currency branches', () => {
-		for (const id of ['deepseek-v4-pro', 'deepseek-v4-flash']) {
+		for (const id of ['deepseek-v4-pro', 'deepseek-v4-flash', 'deepseek-v4.1-flash']) {
 			const preset = listStaticModelPresets().find((p) => p.id === id);
 			assert.ok(preset, id);
 			for (const billing of ['USD', 'CNY'] as const) {


### PR DESCRIPTION
## Summary

Adds the `deepseek-v4.1-flash` preset and updates `deepseek-v4-flash` to the official 2026-09-10 Flash-series list prices (effective Beijing time).

- **New preset `deepseek-v4.1-flash`** — 1M context / 384K max tokens, text modality, released 2026-09-10, with the official launch summary (comprehensively outperforming V4 Pro across performance, cost, speed, and total time in internal and external evaluations, per the vendor note).
- **Repriced `deepseek-v4-flash`** — same off-peak list prices as the new model: USD $0.15 / $0.6 / $0.003 and CNY ¥1 / ¥4 / ¥0.02 per million input / output / cache-read tokens.
- **Peak schedule unchanged** — both Flash models keep the weekday 09:00–12:00 / 14:00–18:00 windows at factor 2; `deepseek-v4-pro` and `deepseek-v3.2` are untouched.
- **Tests** — locked the new Flash list prices and extended the peak-schedule assertions to `deepseek-v4.1-flash`.
- **Docs impact reviewed** — no documentation carries DeepSeek list prices (the presets are the single source), so no doc updates were required; the preset conventions comment now reads "DeepSeek V4 / V4.1".
- **Changeset** — `.changeset/deepseek-v4.1-flash-pricing.md` (patch, `@octafuse/admin`).

Local checks: `npm run test:unit -w @octafuse/admin` (314/314 pass) and `npm run typecheck:admin` pass.

## Target branch

- [x] This PR targets `develop`, or a maintainer has confirmed `main` / another base branch for a release or hotfix.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change (describe migration / release notes impact)
- [ ] Documentation only
- [ ] Build / CI / chore

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) (including the contribution license terms).
- [x] For user-visible behavior or API changes, I updated docs where appropriate.
- [x] I added a changeset for user-visible changes, or documented why it is deferred / unnecessary.
- [x] I ran relevant tests or smoke scripts locally when applicable (e.g. `npm run test:gateway:postgres-smoke`).

## Related issues

None.
